### PR TITLE
Simplify CSS naming

### DIFF
--- a/src/components/AnonymizationView.tsx
+++ b/src/components/AnonymizationView.tsx
@@ -34,7 +34,7 @@ export const AnonymizationView: FunctionComponent<{ schema: TableSchema }> = ({ 
   switch (resultState) {
     case 'failed':
       return (
-        <div className="AnonymizationView AnonymizationView--failed">
+        <div className="AnonymizationView failed">
           <Result status="error" title="Anonymization failed" subTitle="Something went wrong." />
           {demoUtils}
         </div>
@@ -43,7 +43,7 @@ export const AnonymizationView: FunctionComponent<{ schema: TableSchema }> = ({ 
     default: {
       const loaded = computedResult.state === 'completed';
       return (
-        <div className={`AnonymizationView AnonymizationView--${loaded ? 'completed' : 'loading'}`}>
+        <div className={`AnonymizationView ${loaded ? 'completed' : 'loading'}`}>
           <QueryResultsTable loading={!loaded} result={cachedResult} />
           {demoUtils}
         </div>

--- a/src/components/QueryResultsTable.css
+++ b/src/components/QueryResultsTable.css
@@ -1,3 +1,3 @@
-.QueryResultsTable--combined .QueryResultsTable__row--low-count {
+.QueryResultsTable.combined .QueryResultsTable-row.low-count {
   color: #ff4d4f;
 }

--- a/src/components/QueryResultsTable.tsx
+++ b/src/components/QueryResultsTable.tsx
@@ -25,9 +25,9 @@ type TableRowData = {
 
 function rowClassName({ kind }: TableRowData) {
   if (kind === 'anonymized') {
-    return 'QueryResultsTable__row';
+    return 'QueryResultsTable-row';
   } else {
-    return 'QueryResultsTable__row QueryResultsTable__row--low-count';
+    return 'QueryResultsTable-row low-count';
   }
 }
 
@@ -162,7 +162,7 @@ export const QueryResultsTable: FunctionComponent<QueryResultsTableProps> = ({ l
   const data = filterRows(mode, result.rows).map(normalizeRow(result.columns));
 
   return (
-    <div className={`QueryResultsTable QueryResultsTable--${mode}`}>
+    <div className={`QueryResultsTable ${mode}`}>
       <Table
         loading={loading}
         columns={columns}

--- a/src/components/SchemaLoader.css
+++ b/src/components/SchemaLoader.css
@@ -1,4 +1,4 @@
-.SchemaLoader--loading {
+.SchemaLoader.loading {
   padding-top: 48px;
   text-align: center;
 }

--- a/src/components/SchemaLoader.tsx
+++ b/src/components/SchemaLoader.tsx
@@ -12,14 +12,14 @@ export const SchemaLoader: FunctionComponent = () => {
   switch (computedSchema.state) {
     case 'completed':
       return (
-        <div className="SchemaLoader SchemaLoader--completed">
+        <div className="SchemaLoader completed">
           <AnonymizationView schema={computedSchema.value} />
         </div>
       );
 
     case 'failed':
       return (
-        <div className="SchemaLoader SchemaLoader--failed">
+        <div className="SchemaLoader failed">
           <Result
             status="error"
             title="Schema discovery failed"
@@ -30,7 +30,7 @@ export const SchemaLoader: FunctionComponent = () => {
 
     case 'in_progress':
       return (
-        <div className="SchemaLoader SchemaLoader--loading">
+        <div className="SchemaLoader loading">
           <Spin tip="Loading schema..." size="large" />
         </div>
       );


### PR DESCRIPTION
I couldn't get CSS modules to work without adding extra typescript and webpack configs...

Before wasting too much time on that, I have the following proposal:

- Components have a matching class with the same name: `ResultsTable`.
- Children of components are scoped with a dash: `ResultsTable-row`.
- Modifiers are lowercase descriptors of a state: `low-count`, `combined`.

Potentially closes #41.