### PR TITLE
Use on instead of handle for cancel_task in ipcMain

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ async function runTask<T>(taskId: string, runner: (signal: AbortSignal) => Promi
   }
 }
 
-ipcMain.handle('cancel_task', async (_event, taskId: string) => {
+ipcMain.on('cancel_task', async (_event, taskId: string) => {
   console.log(`Cancelling task ${taskId}.`);
   const controller = activeTasks.get(taskId);
   if (controller) {


### PR DESCRIPTION
Looks like they come in pairs:

- `send` and `on` - equivalent to `cast` and `handle_cast`
- `invoke` and `handle` - equivalent to `call` and `handle_call`

With the current `send/handle` pair cancellation was not working... 