### PR TITLE
Pack and set browser window icon.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
   "config": {
     "forge": {
       "packagerConfig": {
-        "extraResource": "bin",
+        "extraResource": [
+          "bin",
+          "assets"
+        ],
         "name": "easy_diffix",
         "icon": "assets/icon"
       },

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,8 @@ const asyncPipeline = util.promisify(stream.pipeline);
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
 
+const resourcesLocation = app.isPackaged ? '..' : '.';
+
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require('electron-squirrel-startup')) {
   app.quit();
@@ -25,6 +27,7 @@ const createWindow = (): void => {
       contextIsolation: false,
       preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
     },
+    icon: path.join(app.getAppPath(), resourcesLocation, 'assets', 'icon.png'),
   });
 
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
@@ -48,9 +51,8 @@ app.on('activate', () => {
   }
 });
 
-const diffixBinLocation = app.isPackaged ? '..' : '.';
 const diffixName = 'OpenDiffix.CLI' + (process.platform === 'win32' ? '.exe' : '');
-const diffixPath = path.join(app.getAppPath(), diffixBinLocation, 'bin', diffixName);
+const diffixPath = path.join(app.getAppPath(), resourcesLocation, 'bin', diffixName);
 
 const activeTasks = new Map<string, AbortController>();
 


### PR DESCRIPTION
Partially fixes #90.

Icon support on Linux is pretty quirky. On my Mint system, the icon appears in the tray for the development build, but it doesn't appear for the production build, and I couldn't figure out why.