### PR TITLE
Make data tables responsive

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,9 +27,11 @@
     }
   },
   "rules": {
+    "no-empty": "warn",
     "prefer-const": "warn",
     "react/prop-types": "off",
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
-    "@typescript-eslint/no-empty-function": "off"
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-non-null-assertion": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
-  "name": "publisher",
+  "name": "easy_diffix",
   "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "easy_diffix",
       "version": "0.1.2",
+      "license": "UNLICENSED",
       "dependencies": {
+        "@rehooks/component-size": "^1.0.3",
         "antd": "^4.16.9",
         "electron-squirrel-startup": "^1.0.0",
         "react": "^17.0.2",
@@ -1141,6 +1144,14 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^9.1.1"
+      }
+    },
+    "node_modules/@rehooks/component-size": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rehooks/component-size/-/component-size-1.0.3.tgz",
+      "integrity": "sha512-pnYld+8SSF2vXwdLOqBGUyOrv/SjzwLjIUcs/4c1JJgR0q4E9eBtBfuZMD6zUD51fvSehSsbnlQMzotSmPTXPg==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -13923,6 +13934,12 @@
       "requires": {
         "@octokit/openapi-types": "^9.1.1"
       }
+    },
+    "@rehooks/component-size": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rehooks/component-size/-/component-size-1.0.3.tgz",
+      "integrity": "sha512-pnYld+8SSF2vXwdLOqBGUyOrv/SjzwLjIUcs/4c1JJgR0q4E9eBtBfuZMD6zUD51fvSehSsbnlQMzotSmPTXPg==",
+      "requires": {}
     },
     "@sindresorhus/is": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
+    "@rehooks/component-size": "^1.0.3",
     "antd": "^4.16.9",
     "electron-squirrel-startup": "^1.0.0",
     "react": "^17.0.2",

--- a/src/components/AnonymizedResultsTable.tsx
+++ b/src/components/AnonymizedResultsTable.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent, useState } from 'react';
-import { Table } from 'antd';
 
-import { DisplayModeSwitch } from '.';
+import { DisplayModeSwitch, ResponsiveTable } from '.';
 import { columnSorter } from '../state';
 import {
   AnonymizedQueryResult,
@@ -36,6 +35,7 @@ function makeColumnData(title: string, dataIndex: string, type: ColumnType) {
     dataIndex,
     render: renderValue,
     sorter: columnSorter(type, dataIndex),
+    ellipsis: true,
   };
 }
 
@@ -107,9 +107,8 @@ export const AnonymizedResultsTable: FunctionComponent<AnonymizedResultsTablePro
 
   return (
     <div className={`AnonymizedResultsTable ${mode}`}>
-      <Table
+      <ResponsiveTable
         key={loading ? 1 : 0 /* Resets internal state */}
-        bordered
         loading={loading}
         columns={columns}
         dataSource={data}

--- a/src/components/DataPreviewTable.tsx
+++ b/src/components/DataPreviewTable.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
-import { Table } from 'antd';
 
+import { ResponsiveTable } from '.';
 import { TableSchema, Value } from '../types';
 import { columnSorter } from '../state';
 
@@ -13,6 +13,7 @@ export const DataPreviewTable: FunctionComponent<DataPreviewTableProps> = ({ sch
     title: col.name,
     dataIndex: i.toString(),
     sorter: columnSorter(col.type, i),
+    ellipsis: true,
   }));
 
   const rows = schema.rowsPreview.map((row, i) => ({
@@ -22,7 +23,7 @@ export const DataPreviewTable: FunctionComponent<DataPreviewTableProps> = ({ sch
 
   return (
     <div className="DataPreviewTable">
-      <Table bordered scroll={{ x: true }} columns={columns} dataSource={rows} />
+      <ResponsiveTable columns={columns} dataSource={rows} />
     </div>
   );
 };

--- a/src/components/ResponsiveTable.css
+++ b/src/components/ResponsiveTable.css
@@ -1,0 +1,4 @@
+.ResponsiveTable .ant-table-cell {
+  min-width: 80px;
+  max-width: 300px;
+}

--- a/src/components/ResponsiveTable.tsx
+++ b/src/components/ResponsiveTable.tsx
@@ -1,0 +1,48 @@
+import React, { useRef } from 'react';
+import { Table, TableProps } from 'antd';
+import useComponentSize from '@rehooks/component-size';
+
+import './ResponsiveTable.css';
+
+const AntTable = React.memo(Table) as unknown as typeof Table;
+
+const MIN_COL_WIDTH = 150;
+const MAX_COL_WIDTH = 300;
+
+function isFixedLayout(width: number, columnCount: number) {
+  if (isNaN(width)) return false;
+  const minWidth = columnCount * MIN_COL_WIDTH;
+  return width >= minWidth;
+}
+
+function maxWidth(columnCount: number) {
+  return Math.max(2, columnCount) * MAX_COL_WIDTH;
+}
+
+function tableProps<T extends TableProps<unknown>>(props: T): T {
+  return props;
+}
+
+const fixedLayoutProps = tableProps({ tableLayout: 'fixed' });
+const scrollableLayoutProps = tableProps({ scroll: { x: true } });
+
+type AnyRecord = Record<string, unknown>;
+
+export type ResponsiveTableProps<T> = TableProps<T>;
+
+export function ResponsiveTable<T extends AnyRecord = AnyRecord>(props: ResponsiveTableProps<T>): JSX.Element {
+  const ref = useRef(null);
+  const { width } = useComponentSize(ref);
+
+  const columnCount = props.columns!.length;
+  const fixed = isFixedLayout(width, columnCount);
+  const layoutProps = fixed ? fixedLayoutProps : scrollableLayoutProps;
+
+  return (
+    <div className="ResponsiveTable" ref={ref}>
+      <div style={{ maxWidth: maxWidth(columnCount) }}>
+        <AntTable bordered {...props} {...layoutProps} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,4 +6,5 @@ export * from './DataPreviewTable';
 export * from './DisplayModeSwitch';
 export * from './FileLoadStep';
 export * from './Notebook';
+export * from './ResponsiveTable';
 export * from './SchemaLoadStep';


### PR DESCRIPTION
Closes #93.

Tables are hard to make responsive.

We have a varying number of columns, and each of them can have an arbitrary data length.

Plus ant design does not support sizing well out of the box. If you want scrolling you cannot have a fixed layout.

Current solution is like this:

If columns are 150px+ wide, we use a fixed layout and limit max table width to `cols * 300px`.

Otherwise we make the table scrollable, 100% width, and limit column widths to 80..300px.

Columns with long content show ellipses instead of breaking lines.
