### PR TITLE
Hide results view when no columns are selected

### DIFF
--- a/src/components/ColumnSelectionStep.css
+++ b/src/components/ColumnSelectionStep.css
@@ -2,3 +2,7 @@
   max-width: 300px;
   border: 1px solid #f0f0f0;
 }
+
+.ColumnSelectionStep-reserved-space {
+  min-height: 700px;
+}

--- a/src/components/ColumnSelectionStep.tsx
+++ b/src/components/ColumnSelectionStep.tsx
@@ -14,6 +14,10 @@ function updateArray<T>(array: T[], index: number, value: T): T[] {
   return copy;
 }
 
+function isTrue(x: boolean) {
+  return x;
+}
+
 export type ColumnSelectionStepProps = {
   schema: TableSchema;
   children: (data: ColumnSelectionStepData) => React.ReactNode;
@@ -51,9 +55,15 @@ export const ColumnSelectionStep: FunctionComponent<ColumnSelectionStepProps> = 
           )}
         />
       </div>
-      {/* Render next step */}
-      <Divider />
-      {children({ columns })}
+      <div className="ColumnSelectionStep-reserved-space">
+        {/* Render next step */}
+        {columns.some(isTrue) && (
+          <>
+            <Divider />
+            {children({ columns })}
+          </>
+        )}
+      </div>
     </>
   );
 };


### PR DESCRIPTION
Closes #106.

Without the reserved space the scrollbar jumps around and creates an unpleasant experience. Not sure how to better fix this...