### PR TITLE
Stop using `int64` types in service responses.

### DIFF
--- a/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
+++ b/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
@@ -5,10 +5,10 @@ open Thoth.Json.Net
 
 type Summary =
   {
-    TotalBuckets: int64
-    LowCountBuckets: int64
-    TotalRows: int64
-    LowCountRows: int64
+    TotalBuckets: int
+    LowCountBuckets: int
+    TotalRows: int
+    LowCountRows: int
     MaxDistortion: float
     MedianDistortion: float
   }
@@ -32,7 +32,7 @@ let rec private encodeValue =
   function
   | Null -> Encode.nil
   | Boolean bool -> Encode.bool bool
-  | Integer int64 -> Encode.int64 int64
+  | Integer int64 -> Encode.float (float int64)
   | Real float -> Encode.float float
   | String string -> Encode.string string
   | List values -> Encode.list (values |> List.map encodeValue)
@@ -52,7 +52,6 @@ let private generateDecoder<'T> = Decode.Auto.generateDecoder<'T> CamelCase
 
 let private extraEncoders =
   Extra.empty
-  |> Extra.withInt64
   |> Extra.withCustom encodeType generateDecoder<ExpressionType>
   |> Extra.withCustom encodeValue generateDecoder<Value>
 

--- a/anonymizer/OpenDiffix.Service/Program.fs
+++ b/anonymizer/OpenDiffix.Service/Program.fs
@@ -65,28 +65,28 @@ let handlePreview { InputPath = inputPath; Rows = rows; Salt = salt; Buckets = b
 
   let result = runQuery query inputPath anonParams
 
-  let mutable totalBuckets = 0L
-  let mutable lowCountBuckets = 0L
-  let mutable totalRows = 0L
-  let mutable lowCountRows = 0L
+  let mutable totalBuckets = 0
+  let mutable lowCountBuckets = 0
+  let mutable totalRows = 0
+  let mutable lowCountRows = 0
 
   let distortions = Array.create result.Rows.Length 0.0
 
   for row in result.Rows do
-    let realCount = unwrapCount row.[1]
-    totalBuckets <- totalBuckets + 1L
+    let realCount = int (unwrapCount row.[1])
+    totalBuckets <- totalBuckets + 1
     totalRows <- totalRows + realCount
 
     if row.[0] = Boolean true then
-      lowCountBuckets <- lowCountBuckets + 1L
+      lowCountBuckets <- lowCountBuckets + 1
       lowCountRows <- lowCountRows + realCount
     else
-      let noisyCount = unwrapCount row.[2]
+      let noisyCount = int (unwrapCount row.[2])
       let distortion = float (abs (noisyCount - realCount)) / float realCount
-      let anonBucket = int (totalBuckets - lowCountBuckets) - 1
+      let anonBucket = totalBuckets - lowCountBuckets - 1
       distortions.[anonBucket] <- distortion
 
-  let anonBuckets = int (totalBuckets - lowCountBuckets)
+  let anonBuckets = totalBuckets - lowCountBuckets
   let distortions = if anonBuckets = 0 then [| 0.0 |] else Array.truncate anonBuckets distortions
   Array.sortInPlace distortions
 


### PR DESCRIPTION
Int64 values are serialized as strings and we want to keep the numeric attribute.
