### PR TITLE
Allow fractional bin sizes

### DIFF
--- a/src/ColumnSelectionStep/ColumnSelectionStep.tsx
+++ b/src/ColumnSelectionStep/ColumnSelectionStep.tsx
@@ -34,10 +34,15 @@ type ColumnState = {
 };
 
 // Values lower than this will cause the anonymizer to crash.
-const BINSIZE_EPSILON = 0.000001;
+const MIN_BIN_SIZE_REAL = 0.000001;
+const MIN_BIN_SIZE_INTEGER = 1;
 
-function getNumericGeneralization({ binSize }: ColumnState): NumericGeneralization | null {
-  if (typeof binSize !== 'number' || binSize < BINSIZE_EPSILON) return null;
+function minBinSize(columnType: ColumnType) {
+  return columnType === 'real' ? MIN_BIN_SIZE_REAL : MIN_BIN_SIZE_INTEGER;
+}
+
+function getNumericGeneralization({ binSize, type }: ColumnState): NumericGeneralization | null {
+  if (typeof binSize !== 'number' || binSize < minBinSize(type)) return null;
   return { binSize };
 }
 
@@ -60,14 +65,15 @@ function GeneralizationControls({
   switch (column.type) {
     case 'integer':
     case 'real': {
-      const isActive = column.binSize !== null && column.binSize >= BINSIZE_EPSILON;
+      const minValue = minBinSize(column.type);
+      const isActive = column.binSize !== null && column.binSize >= minValue;
       return (
         <Form className={'GeneralizationControls' + (isActive ? ' active' : '')} layout="inline">
           <Form.Item label="Bin size" name="binSize">
             <span key={column.resetCount}>
               <InputNumber
                 size="small"
-                min={BINSIZE_EPSILON}
+                min={minValue}
                 value={column.binSize as number}
                 onChange={(binSize) => updateColumn({ binSize })}
               />


### PR DESCRIPTION
Closes #153. Pushing the down arrow on the input gives the epsilon value which is not ideal. If we allow `min={0}` it would show as 0 but binning would not take effect. Not sure which is better.