### PR TITLE
Allow openExternal for mailto links

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,7 @@ function registerProtocols() {
 
 // Main window
 
-const ALLOWED_DOMAINS = ['https://open-diffix.org', 'https://github.com'];
+const ALLOWED_DOMAINS = ['https://open-diffix.org', 'https://github.com', 'mailto:'];
 
 function createWindow() {
   const mainWindow = new BrowserWindow({


### PR DESCRIPTION
Closes #222. Works on my Ubuntu by opening a chrome and navigating to gmail's compose page. There are reports that this may not work on Windows if you don't have a default mail client configured.