### PR TITLE
Add a tooltip for numeric generalization in Preview step

### DIFF
--- a/src/ColumnSelectionStep/ColumnSelectionStep.tsx
+++ b/src/ColumnSelectionStep/ColumnSelectionStep.tsx
@@ -10,9 +10,11 @@ import {
   BucketColumn,
   ColumnType,
   CountInput,
+  NonNullValue,
   NumericGeneralization,
   StringGeneralization,
   TableSchema,
+  TooltipFunction,
 } from '../types';
 
 import './ColumnSelectionStep.css';
@@ -49,9 +51,17 @@ function minBinSize(columnType: ColumnType) {
   return columnType === 'real' ? MIN_BIN_SIZE_REAL : MIN_BIN_SIZE_INTEGER;
 }
 
+function numericGeneralizationTooltip(binSize: number, binStart: number) {
+  return binStart.toString() + '-' + (binStart + binSize).toString();
+}
+
 function getNumericGeneralization({ binSize, type }: ColumnState): NumericGeneralization | null {
   if (typeof binSize !== 'number' || binSize < minBinSize(type)) return null;
   return { binSize };
+}
+
+function getNumericGeneralizationTooltip({ binSize }: ColumnState): TooltipFunction {
+  return binSize ? (v) => numericGeneralizationTooltip(binSize, v as number) : (v: NonNullValue) => v.toString();
 }
 
 function getStringGeneralization({ substringStart, substringLength }: ColumnState): StringGeneralization | null {
@@ -146,7 +156,12 @@ export const ColumnSelectionStep: FunctionComponent<ColumnSelectionStepProps> = 
           switch (type) {
             case 'integer':
             case 'real':
-              return { name, type, generalization: getNumericGeneralization(c) };
+              return {
+                name,
+                type,
+                generalization: getNumericGeneralization(c),
+                valueToTooltip: getNumericGeneralizationTooltip(c),
+              };
             case 'text':
               return { name, type, generalization: getStringGeneralization(c) };
             case 'boolean':

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,8 +31,12 @@ export type TextColumn = { name: string; type: 'text' };
 export type BooleanColumn = { name: string; type: 'boolean' };
 
 export type TableColumn = IntegerColumn | RealColumn | TextColumn | BooleanColumn;
+export type TooltipTableColumn = IntegerColumn | RealColumn;
+export type NoTooltipTableColumn = TextColumn | BooleanColumn;
 
 export type ColumnType = TableColumn['type'];
+export type TooltipColumnType = TooltipTableColumn['type'];
+export type NoTooltipColumnType = NoTooltipTableColumn['type'];
 
 // Query request
 
@@ -46,8 +50,8 @@ export type StringGeneralization = {
 };
 
 export type BucketColumn =
-  | (IntegerColumn & { generalization: NumericGeneralization | null })
-  | (RealColumn & { generalization: NumericGeneralization | null })
+  | (IntegerColumn & { generalization: NumericGeneralization | null; valueToTooltip: TooltipFunction })
+  | (RealColumn & { generalization: NumericGeneralization | null; valueToTooltip: TooltipFunction })
   | (TextColumn & { generalization: StringGeneralization | null })
   | BooleanColumn;
 
@@ -85,7 +89,10 @@ export type ResultColumn = {
 
 export type ResultRow = Value[];
 
+export type NonNullValue = boolean | number | string;
 export type Value = boolean | number | string | null;
+
+export type TooltipFunction = (v: NonNullValue) => string;
 
 // Anonymized query results
 
@@ -95,12 +102,18 @@ export type AnonymizedQueryResult = {
   summary: AnonymizationSummary;
 };
 
-export type AnonymizedResultColumn = {
-  name: string;
-  type: AnonymizedColumnType;
-};
+export type AnonymizedResultColumn =
+  | {
+      name: string;
+      type: TooltipColumnType;
+      valueToTooltip: TooltipFunction;
+    }
+  | {
+      name: string;
+      type: AnonymizedColumnType;
+    };
 
-export type AnonymizedColumnType = ColumnType | 'aggregate';
+export type AnonymizedColumnType = NoTooltipColumnType | 'aggregate';
 
 export type AnonymizedResultRow = { lowCount: boolean; values: AnonymizedValue[] };
 


### PR DESCRIPTION
Closes #152 

It's been a bit difficult to solve this, respecting all separations of concerns requirements. It came out a bit over-functional perhaps, lemme know if you can follow through.

Also, there's an issue with the *styling* of the tooltips. We have 3 options:
1. continue polishing so that it's super consistent across the app
2. be somewhat consistent
3. be noticeably inconsistent, but simplify code

So far I've chosen the (2.). Let's see if you can spot the inconsistency and/or find the code too complex and we'll see, if we need to switch to either 1 or 3. I think current choice of (2.) is "good enough".