### PR TITLE
Add a tooltip for numeric generalization in Preview step - without callbacks

### DIFF
--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check files format
         run: npm run check-format
       - name: Run linter
-        run: npm run lint-ci
+        run: npm run lint
       - name: Build Service
         run: npm run build
       - name: Generate test data

--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check files format
         run: npm run check-format
       - name: Run linter
-        run: npm run lint
+        run: npm run lint-ci
       - name: Build Service
         run: npm run build
       - name: Generate test data

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "eslint --ext .ts,.tsx .",
-    "lint-ci": "eslint --max-warnings 0 --ext .ts,.tsx .",
+    "lint": "eslint --max-warnings 0 --ext .ts,.tsx .",
     "check-format": "prettier --check src && cd anonymizer && dotnet fantomas --check -r .",
     "format": "prettier --write src && cd anonymizer && dotnet fantomas -r ."
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "make": "electron-forge make",
     "publish": "electron-forge publish",
     "lint": "eslint --ext .ts,.tsx .",
+    "lint-ci": "eslint --max-warnings 0 --ext .ts,.tsx .",
     "check-format": "prettier --check src && cd anonymizer && dotnet fantomas --check -r .",
     "format": "prettier --write src && cd anonymizer && dotnet fantomas -r ."
   },

--- a/src/AnonymizationStep/AnonymizationStep.tsx
+++ b/src/AnonymizationStep/AnonymizationStep.tsx
@@ -111,7 +111,7 @@ function AnonymizationResults({ schema, aidColumn, bucketColumns, countInput, re
           <Text>Here is what the result looks like:</Text>
           {result.rows.length === MAX_ROWS && <Text type="secondary"> (only the first {MAX_ROWS} rows are shown)</Text>}
         </div>
-        <AnonymizedResultsTable loading={loading} result={result} />
+        <AnonymizedResultsTable loading={loading} result={result} bucketColumns={bucketColumns} />
       </div>
       <Divider />
       <div className="AnonymizationExports notebook-step">

--- a/src/AnonymizationStep/AnonymizedResultsTable.tsx
+++ b/src/AnonymizationStep/AnonymizedResultsTable.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
+import { Tooltip } from 'antd';
 
 import { columnSorter, formatPercentage, relativeNoise, ResponsiveTable } from '../shared';
 import {
@@ -9,6 +10,7 @@ import {
   DisplayMode,
   RowData,
   Value,
+  BucketColumn,
 } from '../types';
 import { DisplayModeSwitch } from './DisplayModeSwitch';
 
@@ -21,54 +23,97 @@ type TableRowData = RowData & {
 
 // Columns
 
-function renderValue(v: Value) {
-  if (v === null) {
-    return <i>NULL</i>;
+function cellDefaultTooltip(displayValue: string) {
+  return <Tooltip title={displayValue}>{displayValue}</Tooltip>;
+}
+
+function cellNullTooltip() {
+  return (
+    <Tooltip title="NULL">
+      <i>NULL</i>
+    </Tooltip>
+  );
+}
+
+function cellNumericGeneralizedTooltip(binSize: number, v: number) {
+  const displayValue = v.toString();
+  const tooltip = `[${v}; ${v + binSize})`;
+  return <Tooltip title={tooltip}>{displayValue}</Tooltip>;
+}
+
+function cellTooltip(bucketColumn: BucketColumn | undefined, v: number | boolean | string) {
+  if (
+    bucketColumn &&
+    (bucketColumn.type === 'integer' || bucketColumn.type === 'real') &&
+    bucketColumn.generalization &&
+    bucketColumn.generalization.binSize
+  ) {
+    return cellNumericGeneralizedTooltip(bucketColumn.generalization.binSize, v as number);
   } else {
-    return v.toString();
+    return cellDefaultTooltip(v.toString());
   }
 }
 
+function renderValue(v: Value) {
+  // with `ellipsis: { showTitle: false }` set for the column, we're disabling the default tooltip
+  // so that the styling of tooltips is more consistent. This forces us to provide Tooltip in all cases
+  // even if the tooltip shown is same as the cell value.
+  if (v === null) {
+    return cellNullTooltip();
+  } else {
+    return cellDefaultTooltip(v.toString());
+  }
+}
+
+function buildRenderTooltipValue(column: AnonymizedResultColumn, bucketColumns: BucketColumn[]) {
+  const bucketColumn = bucketColumns.find((c) => c.name === column.name);
+  return (v: Value) => {
+    // see note on `ellipsis` above
+    if (v === null) {
+      return cellNullTooltip();
+    } else {
+      return cellTooltip(bucketColumn, v);
+    }
+  };
+}
+
 function renderLowCountValue(v: Value) {
-  return v === null ? '-' : v.toString();
+  // see note on `ellipsis` above
+  return cellDefaultTooltip(v === null ? '-' : v.toString());
 }
 
 function renderRelativeNoiseValue(v: Value) {
-  return v === null ? '-' : formatPercentage(v as number);
+  // see note on `ellipsis` above
+  return cellDefaultTooltip(v === null ? '-' : formatPercentage(v as number));
 }
 
-function makeColumnData(
-  title: string,
-  dataIndex: string,
-  type: ColumnType,
-  render: (v: Value) => React.ReactNode = renderValue,
-) {
+function makeColumnData(title: string, dataIndex: string, type: ColumnType, render: (v: Value) => React.ReactNode) {
   return {
     title,
     dataIndex,
     render,
     sorter: columnSorter(type, dataIndex),
-    ellipsis: true,
+    ellipsis: { showTitle: false },
   };
 }
 
 const AGG_COLUMN_TYPE = 'real';
 
-const mapColumn = (mode: DisplayMode) => (column: AnonymizedResultColumn, i: number) => {
+const mapColumn = (mode: DisplayMode, bucketColumns: BucketColumn[]) => (column: AnonymizedResultColumn, i: number) => {
   if (column.type === 'aggregate') {
     switch (mode) {
       case 'anonymized':
-        return [makeColumnData(column.name, i + '_anon', AGG_COLUMN_TYPE)];
+        return [makeColumnData(column.name, i + '_anon', AGG_COLUMN_TYPE, renderValue)];
       case 'combined':
         return [
           makeColumnData(column.name + ' (anonymized)', i + '_anon', AGG_COLUMN_TYPE, renderLowCountValue),
-          makeColumnData(column.name + ' (original)', i + '_real', AGG_COLUMN_TYPE),
+          makeColumnData(column.name + ' (original)', i + '_real', AGG_COLUMN_TYPE, renderValue),
           makeColumnData('Distortion', i + '_diff', 'real', renderRelativeNoiseValue),
         ];
     }
   }
 
-  return [makeColumnData(column.name, i.toString(), column.type)];
+  return [makeColumnData(column.name, i.toString(), column.type, buildRenderTooltipValue(column, bucketColumns))];
 };
 
 // Rows
@@ -112,12 +157,17 @@ function mapRow(row: AnonymizedResultRow, i: number) {
 export type AnonymizedResultsTableProps = {
   loading: boolean;
   result: AnonymizedQueryResult;
+  bucketColumns: BucketColumn[];
 };
 
-export const AnonymizedResultsTable: FunctionComponent<AnonymizedResultsTableProps> = ({ loading, result }) => {
+export const AnonymizedResultsTable: FunctionComponent<AnonymizedResultsTableProps> = ({
+  loading,
+  result,
+  bucketColumns,
+}) => {
   const [mode, setMode] = useState<DisplayMode>('anonymized');
 
-  const columns = result.columns.flatMap(mapColumn(mode));
+  const columns = result.columns.flatMap(mapColumn(mode, bucketColumns));
   const data = filterRows(mode, result.rows).map(mapRow);
 
   return (


### PR DESCRIPTION
This is a simplified version of #253 . Closes #152 

From my own gut feel and the comments I gathered that the callback model isn't working out. This version keeps everything to the `AnonymizedResultTable` component, which only needs to be aware of the `bucketColumns` context from previous step, which I think is cleaner than the type-mess that the previous version caused.

Sorry about two reviews, I hope this is now much easier to review.