### PR TITLE
Allow passing custom anonParams to the OpenDiffix.Service

### DIFF
--- a/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
@@ -15,7 +15,9 @@ type TempFile() =
     member this.Dispose() = System.IO.File.Delete(path)
 
 let defaultAnonParams =
-  $"""{{"suppression":{{"lowThreshold":3,"sD":1,"lowMeanGap":2}},"outlierCount":{{"lower":2,"upper":5}},"topCount":{{"lower":2,"upper":5}},"noiseSD":1.0}}"""
+  $"""
+  {{"suppression":{{"lowThreshold":3,"sD":1,"lowMeanGap":2}},"outlierCount":{{"lower":2,"upper":5}},"topCount":{{"lower":2,"upper":5}},"noiseSD":1.0}}
+  """
 
 [<Fact>]
 let ``Handles Load request`` () =
@@ -56,9 +58,14 @@ let ``Handles Preview request`` () =
 
 [<Fact>]
 let ``Handles Preview request with custom anonParams`` () =
+  let anonParams =
+    $"""
+    {{"suppression":{{"lowThreshold":0,"sD":0,"lowMeanGap":0}},"outlierCount":{{"lower":2,"upper":5}},"topCount":{{"lower":2,"upper":5}},"noiseSD":1.0}}
+    """
+
   let requestCustom =
     $"""
-    {{"type":"Preview","inputPath":"%s{dataPath}","aidColumn":"id","salt":"1","anonParams":{{"suppression":{{"lowThreshold":0,"sD":0,"lowMeanGap":0}},"outlierCount":{{"lower":2,"upper":5}},"topCount":{{"lower":2,"upper":5}},"noiseSD":1.0}},"buckets":["age","city"],"countInput":"Rows","rows":1000}}
+    {{"type":"Preview","inputPath":"%s{dataPath}","aidColumn":"id","salt":"1","anonParams":%s{anonParams},"buckets":["age","city"],"countInput":"Rows","rows":1000}}
     """
 
   let responseCustom = requestCustom |> mainCore
@@ -85,9 +92,14 @@ let ``Handles Export request`` () =
 let ``Handles Export request with custom anonParams`` () =
   use outputFile = new TempFile()
 
+  let anonParams =
+    $"""
+    {{"suppression":{{"lowThreshold":300,"sD":1,"lowMeanGap":2}},"outlierCount":{{"lower":2,"upper":5}},"topCount":{{"lower":2,"upper":5}},"noiseSD":1.0}}
+    """
+
   let requestCustom =
     $"""
-    {{"type":"Export","inputPath":"%s{dataPath}","aidColumn":"id","salt":"1","anonParams":{{"suppression":{{"lowThreshold":300,"sD":1,"lowMeanGap":2}},"outlierCount":{{"lower":2,"upper":5}},"topCount":{{"lower":2,"upper":5}},"noiseSD":1.0}},"buckets":["age","city"],"countInput":"Rows","outputPath":"%s{outputFile.Path}"}}
+    {{"type":"Export","inputPath":"%s{dataPath}","aidColumn":"id","salt":"1","anonParams":%s{anonParams},"buckets":["age","city"],"countInput":"Rows","outputPath":"%s{outputFile.Path}"}}
     """
 
   requestCustom |> mainCore |> should equal ""

--- a/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
+++ b/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
@@ -23,6 +23,16 @@ type CountInput =
   | Rows
   | Entities
 
+type RequestAnonParams =
+  {
+    Suppression: CommonTypes.SuppressionParams
+
+    // Count params
+    OutlierCount: CommonTypes.Interval
+    TopCount: CommonTypes.Interval
+    NoiseSD: float
+  }
+
 type PreviewRequest =
   {
     InputPath: string
@@ -31,6 +41,7 @@ type PreviewRequest =
     Salt: string
     Buckets: string []
     CountInput: CountInput
+    AnonParams: Option<RequestAnonParams>
   }
 
 type ExportRequest =
@@ -41,6 +52,7 @@ type ExportRequest =
     Buckets: string []
     OutputPath: string
     CountInput: CountInput
+    AnonParams: Option<RequestAnonParams>
   }
 
 type HasMissingValuesRequest = { InputPath: string; AidColumn: string }

--- a/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
+++ b/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
@@ -25,11 +25,11 @@ type CountInput =
 
 type RequestAnonParams =
   {
-    Suppression: CommonTypes.SuppressionParams
+    Suppression: SuppressionParams
 
     // Count params
-    OutlierCount: CommonTypes.Interval
-    TopCount: CommonTypes.Interval
+    OutlierCount: Interval
+    TopCount: Interval
     NoiseSD: float
   }
 
@@ -41,7 +41,7 @@ type PreviewRequest =
     Salt: string
     Buckets: string []
     CountInput: CountInput
-    AnonParams: Option<RequestAnonParams>
+    AnonParams: RequestAnonParams
   }
 
 type ExportRequest =
@@ -52,7 +52,7 @@ type ExportRequest =
     Buckets: string []
     OutputPath: string
     CountInput: CountInput
-    AnonParams: Option<RequestAnonParams>
+    AnonParams: RequestAnonParams
   }
 
 type HasMissingValuesRequest = { InputPath: string; AidColumn: string }

--- a/anonymizer/OpenDiffix.Service/Program.fs
+++ b/anonymizer/OpenDiffix.Service/Program.fs
@@ -47,6 +47,23 @@ let unwrapCount count =
   | Integer count -> count
   | _ -> failwith "Unexpected value type received for count."
 
+let getAnonParams (requestAnonParams: Option<RequestAnonParams>) (salt: string) =
+  match requestAnonParams with
+  | Some customAnonParams ->
+    {
+      TableSettings = Map.empty
+      Salt = Text.Encoding.UTF8.GetBytes(salt)
+      Suppression = customAnonParams.Suppression
+      OutlierCount = customAnonParams.OutlierCount
+      TopCount = customAnonParams.TopCount
+      NoiseSD = customAnonParams.NoiseSD
+    }
+  | None ->
+    { AnonymizationParams.Default with
+        Salt = Text.Encoding.UTF8.GetBytes(salt)
+        Suppression = { SuppressionParams.Default with LowThreshold = 3 }
+    }
+
 let handlePreview
   {
     InputPath = inputPath
@@ -55,9 +72,10 @@ let handlePreview
     Salt = salt
     Buckets = buckets
     CountInput = countInput
+    AnonParams = requestAnonParams
   }
   =
-  let anonParams = { AnonymizationParams.Default with Salt = Text.Encoding.UTF8.GetBytes(salt) }
+  let anonParams = getAnonParams requestAnonParams salt
 
   let countInput =
     match countInput with
@@ -121,13 +139,10 @@ let handleExport
     Buckets = buckets
     CountInput = countInput
     OutputPath = outputPath
+    AnonParams = requestAnonParams
   }
   =
-  let anonParams =
-    { AnonymizationParams.Default with
-        Salt = Text.Encoding.UTF8.GetBytes(salt)
-        Suppression = { SuppressionParams.Default with LowThreshold = 3 }
-    }
+  let anonParams = getAnonParams requestAnonParams salt
 
   let countInput =
     match countInput with

--- a/anonymizer/OpenDiffix.Service/Program.fs
+++ b/anonymizer/OpenDiffix.Service/Program.fs
@@ -47,22 +47,15 @@ let unwrapCount count =
   | Integer count -> count
   | _ -> failwith "Unexpected value type received for count."
 
-let getAnonParams (requestAnonParams: Option<RequestAnonParams>) (salt: string) =
-  match requestAnonParams with
-  | Some customAnonParams ->
-    {
-      TableSettings = Map.empty
-      Salt = Text.Encoding.UTF8.GetBytes(salt)
-      Suppression = customAnonParams.Suppression
-      OutlierCount = customAnonParams.OutlierCount
-      TopCount = customAnonParams.TopCount
-      NoiseSD = customAnonParams.NoiseSD
-    }
-  | None ->
-    { AnonymizationParams.Default with
-        Salt = Text.Encoding.UTF8.GetBytes(salt)
-        Suppression = { SuppressionParams.Default with LowThreshold = 3 }
-    }
+let getAnonParams (requestAnonParams: RequestAnonParams) (salt: string) =
+  {
+    TableSettings = Map.empty
+    Salt = Text.Encoding.UTF8.GetBytes(salt)
+    Suppression = requestAnonParams.Suppression
+    OutlierCount = requestAnonParams.OutlierCount
+    TopCount = requestAnonParams.TopCount
+    NoiseSD = requestAnonParams.NoiseSD
+  }
 
 let handlePreview
   {

--- a/src/shared/anonymizer.ts
+++ b/src/shared/anonymizer.ts
@@ -111,17 +111,17 @@ class DiffixAnonymizer implements Anonymizer {
         inputPath: schema.file.path,
         aidColumn: `"${aidColumn}"`,
         salt: schema.salt,
-        // TODO: send optional `anonParams` from the UI, template:
-        // anonParams: {
-        //   suppression: {
-        //     lowThreshold: 3,
-        //     sD: 1.0,
-        //     lowMeanGap: 2.0,
-        //   },
-        //   outlierCount: { lower: 2, upper: 5 },
-        //   topCount: { lower: 2, upper: 5 },
-        //   noiseSD: 1.0,
-        // },
+        // TODO: send optional `anonParams` from the UI:
+        anonParams: {
+          suppression: {
+            lowThreshold: 3,
+            sD: 1.0,
+            lowMeanGap: 2.0,
+          },
+          outlierCount: { lower: 2, upper: 5 },
+          topCount: { lower: 2, upper: 5 },
+          noiseSD: 1.0,
+        },
         buckets: this.mapBucketsToSQL(bucketColumns),
         countInput,
         rows: 1000,
@@ -157,17 +157,17 @@ class DiffixAnonymizer implements Anonymizer {
         inputPath: schema.file.path,
         aidColumn: `"${aidColumn}"`,
         salt: schema.salt,
-        // TODO: send optional `anonParams` from the UI, template:
-        // anonParams: {
-        //   suppression: {
-        //     lowThreshold: 3,
-        //     sD: 1.0,
-        //     lowMeanGap: 2.0,
-        //   },
-        //   outlierCount: { lower: 2, upper: 5 },
-        //   topCount: { lower: 2, upper: 5 },
-        //   noiseSD: 1.0,
-        // },
+        // TODO: send optional `anonParams` from the UI:
+        anonParams: {
+          suppression: {
+            lowThreshold: 3,
+            sD: 1.0,
+            lowMeanGap: 2.0,
+          },
+          outlierCount: { lower: 2, upper: 5 },
+          topCount: { lower: 2, upper: 5 },
+          noiseSD: 1.0,
+        },
         buckets: this.mapBucketsToSQL(bucketColumns),
         countInput,
         outputPath: outFileName,

--- a/src/shared/anonymizer.ts
+++ b/src/shared/anonymizer.ts
@@ -111,6 +111,17 @@ class DiffixAnonymizer implements Anonymizer {
         inputPath: schema.file.path,
         aidColumn: `"${aidColumn}"`,
         salt: schema.salt,
+        // TODO: send optional `anonParams` from the UI, template:
+        // anonParams: {
+        //   suppression: {
+        //     lowThreshold: 3,
+        //     sD: 1.0,
+        //     lowMeanGap: 2.0,
+        //   },
+        //   outlierCount: { lower: 2, upper: 5 },
+        //   topCount: { lower: 2, upper: 5 },
+        //   noiseSD: 1.0,
+        // },
         buckets: this.mapBucketsToSQL(bucketColumns),
         countInput,
         rows: 1000,
@@ -118,6 +129,8 @@ class DiffixAnonymizer implements Anonymizer {
       const result = (await window.callService(request, signal)) as PreviewResponse;
 
       const rows: AnonymizedResultRow[] = result.rows.map((row) => {
+        // NOTE: the position of `diffix_low_count` and other columns must be kept in sync with the
+        // Preview request's `SELECT` in `anonymizer/OpenDiffix.Service/Program.fs`.
         const lowCount = row[0] as boolean;
         return {
           lowCount,
@@ -144,6 +157,17 @@ class DiffixAnonymizer implements Anonymizer {
         inputPath: schema.file.path,
         aidColumn: `"${aidColumn}"`,
         salt: schema.salt,
+        // TODO: send optional `anonParams` from the UI, template:
+        // anonParams: {
+        //   suppression: {
+        //     lowThreshold: 3,
+        //     sD: 1.0,
+        //     lowMeanGap: 2.0,
+        //   },
+        //   outlierCount: { lower: 2, upper: 5 },
+        //   topCount: { lower: 2, upper: 5 },
+        //   noiseSD: 1.0,
+        // },
         buckets: this.mapBucketsToSQL(bucketColumns),
         countInput,
         outputPath: outFileName,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,6 +111,30 @@ export type AnonymizedAggregate = {
   anonValue: number | null;
 };
 
+// AnonymizationParams
+
+export type Interval = {
+  lower: number;
+  upper: number;
+};
+
+export type SuppressionParams = {
+  lowThreshold: number;
+  sD: number;
+  lowMeanGap: number;
+};
+
+export type AnonymizationParams = {
+  // we're excluding TableSettings and Salt, as compared to `reference`, since
+  // both are handled differently in Diffix for Desktop
+  suppression: SuppressionParams;
+
+  // Count params
+  outlierCount: Interval;
+  topCount: Interval;
+  noiseSD: number;
+};
+
 // API
 
 export type Anonymizer = {


### PR DESCRIPTION
Behavior of Diffix for Desktop remains unchanged - since `anonParams` can be omitted in the `Preview` and `Export` requests, everything should work the same on the GUI.

The next step is to supply `anonParams` from the GUI and (possibly) turn off the defaults used on `OpenDiffix.Service` end.

One tiny spot I don't necessarily like is that our types `CommonTypes.AnonymizationParams` and `RequestAnonParams` diverge slightly. I think this is still acceptable - we don't necessarily want to allow custom `TableSettings` to slip in, which would be possible if we used the format of `CommonTypes.AnonymizationParams` for the JSON communication. The way `salt` is calculated in desktop is also slightly separate from the remainder of the params, so I've decided to keep it separate in the JSON API.

I'm taking the liberty to roll with this PR as it is now, postponing the discussion about where and how exactly between `desktop`, `service` and `reference` will the default `anonParams` "live"