### PR TITLE
Make the loading animation reveal previous anonymization summary

### DIFF
--- a/src/AnonymizationStep/AnonymizationStep.css
+++ b/src/AnonymizationStep/AnonymizationStep.css
@@ -10,21 +10,10 @@
   margin: 32px 0;
 }
 
-.TextPlaceholder {
-  display: inline-block;
-  vertical-align: middle;
-  width: 120px;
-  height: 1em;
-  background: linear-gradient(
-    90deg,
-    rgba(190, 190, 190, 0.2) 25%,
-    rgba(129, 129, 129, 0.24) 37%,
-    rgba(190, 190, 190, 0.2) 63%
-  );
-  background-size: 400% 100%;
-  animation: ant-skeleton-loading 1.4s ease infinite;
-}
-
 .AnonymizationExport-reserved-space {
   min-height: 400px;
+}
+
+.AnonymizationSummary.loading {
+  text-align: center;
 }

--- a/src/AnonymizationStep/AnonymizationStep.css
+++ b/src/AnonymizationStep/AnonymizationStep.css
@@ -1,4 +1,4 @@
-.AnonymizationSummary-descriptions {
+.AnonymizationSummary-spin-container {
   max-width: 780px;
 }
 
@@ -12,8 +12,4 @@
 
 .AnonymizationExport-reserved-space {
   min-height: 400px;
-}
-
-.AnonymizationSummary.loading {
-  text-align: center;
 }

--- a/src/AnonymizationStep/AnonymizationStep.tsx
+++ b/src/AnonymizationStep/AnonymizationStep.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
-import { Button, Descriptions, Divider, message, Result, Typography } from 'antd';
+import { Button, Descriptions, Divider, message, Result, Space, Spin, Typography } from 'antd';
 import { DownloadOutlined } from '@ant-design/icons';
 
 import { NotebookNavAnchor, NotebookNavStep } from '../Notebook';
@@ -42,42 +42,45 @@ const emptySummary: AnonymizationSummary = {
 
 const emptyQueryResult: AnonymizedQueryResult = { columns: [], rows: [], summary: emptySummary };
 
-function TextPlaceholder() {
-  return <span className="TextPlaceholder" />;
+function summaryDescriptions(summary: AnonymizationSummary) {
+  return (
+    <Descriptions className="AnonymizationSummary-descriptions" layout="vertical" bordered column={{ sm: 2, md: 4 }}>
+      <Descriptions.Item label="Suppressed Count">
+        {`${summary.lowCountRows} of ${summary.totalRows} (${formatPercentage(
+          summary.lowCountRows / summary.totalRows,
+        )})`}
+      </Descriptions.Item>
+      <Descriptions.Item label="Suppressed Bins">
+        {`${summary.lowCountBuckets} of ${summary.totalBuckets} (${formatPercentage(
+          summary.lowCountBuckets / summary.totalBuckets,
+        )})`}
+      </Descriptions.Item>
+      <Descriptions.Item label="Median Distortion">{formatPercentage(summary.medianDistortion)}</Descriptions.Item>
+      <Descriptions.Item label="Maximum Distortion">{formatPercentage(summary.maxDistortion)}</Descriptions.Item>
+    </Descriptions>
+  );
 }
 
 function AnonymizationSummary({ result: { summary }, loading }: CommonProps) {
   return (
-    <div className="AnonymizationSummary loading notebook-step">
+    <>
       <NotebookNavAnchor step={NotebookNavStep.AnonymizationSummary} status={loading ? 'loading' : 'done'} />
       <Title level={3}>Anonymization summary</Title>
-      <Descriptions className="AnonymizationSummary-descriptions" layout="vertical" bordered column={{ sm: 2, md: 4 }}>
-        <Descriptions.Item label="Suppressed Count">
-          {!loading ? (
-            `${summary.lowCountRows} of ${summary.totalRows} (${formatPercentage(
-              summary.lowCountRows / summary.totalRows,
-            )})`
-          ) : (
-            <TextPlaceholder />
-          )}
-        </Descriptions.Item>
-        <Descriptions.Item label="Suppressed Bins">
-          {!loading ? (
-            `${summary.lowCountBuckets} of ${summary.totalBuckets} (${formatPercentage(
-              summary.lowCountBuckets / summary.totalBuckets,
-            )})`
-          ) : (
-            <TextPlaceholder />
-          )}
-        </Descriptions.Item>
-        <Descriptions.Item label="Median Distortion">
-          {!loading ? formatPercentage(summary.medianDistortion) : <TextPlaceholder />}
-        </Descriptions.Item>
-        <Descriptions.Item label="Maximum Distortion">
-          {!loading ? formatPercentage(summary.maxDistortion) : <TextPlaceholder />}
-        </Descriptions.Item>
-      </Descriptions>
-    </div>
+      {summary === emptySummary ? (
+        <div className="AnonymizationSummary loading notebook-step">
+          <Space direction="vertical">
+            <Spin size="large" />
+            <Text type="secondary">Anonymizing data</Text>
+          </Space>
+        </div>
+      ) : loading ? (
+        <div className="AnonymizationSummary completed notebook-step">
+          <Spin>{summaryDescriptions(summary)}</Spin>
+        </div>
+      ) : (
+        <div className="AnonymizationSummary completed notebook-step">{summaryDescriptions(summary)}</div>
+      )}
+    </>
   );
 }
 

--- a/src/AnonymizationStep/AnonymizationStep.tsx
+++ b/src/AnonymizationStep/AnonymizationStep.tsx
@@ -63,24 +63,22 @@ function summaryDescriptions(summary: AnonymizationSummary) {
 
 function AnonymizationSummary({ result: { summary }, loading }: CommonProps) {
   return (
-    <>
+    <div className="AnonymizationSummary notebook-step">
       <NotebookNavAnchor step={NotebookNavStep.AnonymizationSummary} status={loading ? 'loading' : 'done'} />
       <Title level={3}>Anonymization summary</Title>
       {summary === emptySummary ? (
-        <div className="AnonymizationSummary loading notebook-step">
+        <div className="text-center">
           <Space direction="vertical">
             <Spin size="large" />
             <Text type="secondary">Anonymizing data</Text>
           </Space>
         </div>
-      ) : loading ? (
-        <div className="AnonymizationSummary completed notebook-step">
-          <Spin>{summaryDescriptions(summary)}</Spin>
-        </div>
       ) : (
-        <div className="AnonymizationSummary completed notebook-step">{summaryDescriptions(summary)}</div>
+        <div className="AnonymizationSummary-spin-container">
+          <Spin spinning={loading}>{summaryDescriptions(summary)}</Spin>
+        </div>
       )}
-    </>
+    </div>
   );
 }
 

--- a/src/App/App.css
+++ b/src/App/App.css
@@ -35,3 +35,7 @@ body {
 .mb-1 {
   margin-bottom: 8px;
 }
+
+.text-center {
+  text-align: center;
+}

--- a/src/SchemaLoadStep/SchemaLoadStep.css
+++ b/src/SchemaLoadStep/SchemaLoadStep.css
@@ -1,3 +1,0 @@
-.SchemaLoadStep.loading {
-  text-align: center;
-}

--- a/src/SchemaLoadStep/SchemaLoadStep.tsx
+++ b/src/SchemaLoadStep/SchemaLoadStep.tsx
@@ -6,8 +6,6 @@ import { File, TableSchema } from '../types';
 import { DataPreviewTable } from './DataPreviewTable';
 import { useSchema } from './use-schema';
 
-import './SchemaLoadStep.css';
-
 const { Text, Title } = Typography;
 
 export type SchemaLoadStepProps = {
@@ -62,7 +60,7 @@ export const SchemaLoadStep: FunctionComponent<SchemaLoadStepProps> = ({ childre
 
     case 'in_progress':
       return (
-        <div className="SchemaLoadStep notebook-step loading">
+        <div className="SchemaLoadStep notebook-step text-center">
           <NotebookNavAnchor step={NotebookNavStep.DataPreview} status="loading" />
           <Space direction="vertical">
             <Spin size="large" />


### PR DESCRIPTION
Follows up after #262 and discussion therein - it is very useful to see the "previous" anonymization summary, when the new one is calculating after having changed the anonymization parameters. This change accomplishes that
![Screenshot from 2021-11-23 11-11-52](https://user-images.githubusercontent.com/5735525/143005942-3f0e81e1-d9d2-4e00-b850-4bd3812eb9d5.png)

The "spinner" look and feel is now the same as for the Schema Load step and the Anonymized Results table.
