### PR TITLE
Make navbar collapsible using our custom Layout component

### DIFF
--- a/src/Notebook/Notebook.css
+++ b/src/Notebook/Notebook.css
@@ -3,6 +3,6 @@
 }
 
 .Notebook-content {
-  padding: 0 32px 96px 32px;
+  padding: 0 32px 96px 8px;
   overflow-y: scroll;
 }

--- a/src/Notebook/Notebook.css
+++ b/src/Notebook/Notebook.css
@@ -6,3 +6,20 @@
   padding: 0 32px 96px 32px;
   overflow-y: scroll;
 }
+
+.Notebook-sidebar {
+  display: flex;
+}
+
+.Notebook-sidebar-right,
+.Notebook-sidebar-left {
+  display: inline-block;
+}
+
+.Notebook-sidebar .ant-btn {
+  height: 0;
+  width: 0;
+  padding: 0 5px 0 0;
+  display: inline-block;
+  border: none;
+}

--- a/src/Notebook/Notebook.css
+++ b/src/Notebook/Notebook.css
@@ -6,20 +6,3 @@
   padding: 0 32px 96px 32px;
   overflow-y: scroll;
 }
-
-.Notebook-sidebar {
-  display: flex;
-}
-
-.Notebook-sidebar-right,
-.Notebook-sidebar-left {
-  display: inline-block;
-}
-
-.Notebook-sidebar .ant-btn {
-  height: 0;
-  width: 0;
-  padding: 0 5px 0 0;
-  display: inline-block;
-  border: none;
-}

--- a/src/Notebook/Notebook.tsx
+++ b/src/Notebook/Notebook.tsx
@@ -1,5 +1,6 @@
-import React, { FunctionComponent } from 'react';
-import { Divider } from 'antd';
+import React, { FunctionComponent, useState } from 'react';
+import { Button, Divider } from 'antd';
+import { LeftCircleOutlined, RightCircleOutlined } from '@ant-design/icons';
 
 import { FileLoadStep } from '../FileLoadStep';
 import { SchemaLoadStep } from '../SchemaLoadStep';
@@ -19,13 +20,26 @@ export type NotebookProps = {
 };
 
 export const Notebook: FunctionComponent<NotebookProps> = ({ isActive, onTitleChange }) => {
+  const [collapsed, setCollapsed] = useState(false);
+
   return (
     <NotebookNavProvider isActive={isActive}>
       <Layout className="Notebook">
-        <Layout.Sidebar className="Notebook-sidebar">
-          <NotebookNav />
-          <Divider style={{ margin: '16px 0' }} />
-          <NotebookHelp />
+        <Layout.Sidebar collapsed={collapsed} className="Notebook-sidebar">
+          <div className="Notebook-sidebar-left">
+            <NotebookNav collapsed={collapsed} />
+            {collapsed ? null : (
+              <>
+                <Divider style={{ margin: '16px 0' }} />
+                <NotebookHelp />
+              </>
+            )}
+          </div>
+          <Button
+            className="Notebook-sidebar-right"
+            icon={collapsed ? <RightCircleOutlined /> : <LeftCircleOutlined />}
+            onClick={() => setCollapsed(!collapsed)}
+          />
         </Layout.Sidebar>
         <Layout.Content className="Notebook-content">
           <FileLoadStep onLoad={(file) => onTitleChange(file.name)}>

--- a/src/Notebook/Notebook.tsx
+++ b/src/Notebook/Notebook.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useState } from 'react';
 import { Button, Divider } from 'antd';
-import { LeftCircleOutlined, RightCircleOutlined } from '@ant-design/icons';
+import { MenuUnfoldOutlined, MenuFoldOutlined } from '@ant-design/icons';
 
 import { FileLoadStep } from '../FileLoadStep';
 import { SchemaLoadStep } from '../SchemaLoadStep';
@@ -26,21 +26,20 @@ export const Notebook: FunctionComponent<NotebookProps> = ({ isActive, onTitleCh
     <NotebookNavProvider isActive={isActive}>
       <Layout className="Notebook">
         <Layout.Sidebar collapsed={collapsed} className="Notebook-sidebar">
-          <div className="Notebook-sidebar-left">
-            <NotebookNav collapsed={collapsed} />
-            {collapsed ? null : (
-              <>
-                <Divider style={{ margin: '16px 0' }} />
-                <NotebookHelp />
-              </>
-            )}
-          </div>
+          <NotebookNav collapsed={collapsed} />
+          {collapsed ? null : (
+            <>
+              <Divider style={{ margin: '16px 0' }} />
+              <NotebookHelp />
+            </>
+          )}
+        </Layout.Sidebar>
+        <Layout.CollapseButton className="Notebook-collapse-button">
           <Button
-            className="Notebook-sidebar-right"
-            icon={collapsed ? <RightCircleOutlined /> : <LeftCircleOutlined />}
+            icon={collapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
             onClick={() => setCollapsed(!collapsed)}
           />
-        </Layout.Sidebar>
+        </Layout.CollapseButton>
         <Layout.Content className="Notebook-content">
           <FileLoadStep onLoad={(file) => onTitleChange(file.name)}>
             {({ file }) => (

--- a/src/shared/Layout.css
+++ b/src/shared/Layout.css
@@ -8,7 +8,14 @@
 }
 
 .Layout > .Layout-sidebar {
-  flex: 0 0 350px;
+  flex: 0 0 370px;
+  overflow-y: auto;
+  padding: 24px;
+  border-right: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.Layout > .Layout-sidebar-collapsed {
+  flex: 0 0 100px;
   overflow-y: auto;
   padding: 24px;
   border-right: 1px solid rgba(0, 0, 0, 0.06);

--- a/src/shared/Layout.css
+++ b/src/shared/Layout.css
@@ -8,17 +8,22 @@
 }
 
 .Layout > .Layout-sidebar {
-  flex: 0 0 370px;
+  flex: 0 0 350px;
   overflow-y: auto;
   padding: 24px;
   border-right: 1px solid rgba(0, 0, 0, 0.06);
 }
 
 .Layout > .Layout-sidebar-collapsed {
-  flex: 0 0 100px;
+  flex: 0 0 70px;
   overflow-y: auto;
   padding: 24px;
   border-right: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.Layout > .Layout-collapse-button .ant-btn {
+  width: 0;
+  border: none;
 }
 
 @media screen and (max-width: 800px) {

--- a/src/shared/Layout.css
+++ b/src/shared/Layout.css
@@ -22,8 +22,7 @@
 }
 
 .Layout > .Layout-collapse-button .ant-btn {
-  width: 0;
-  border: none;
+  box-shadow: 4px 0px 8px 0px rgb(0 0 0 / 8%);
 }
 
 @media screen and (max-width: 800px) {

--- a/src/shared/Layout.tsx
+++ b/src/shared/Layout.tsx
@@ -9,6 +9,7 @@ export type LayoutProps = {
 
 export const Layout: FunctionComponent<LayoutProps> & {
   Sidebar: FunctionComponent<LayoutProps & { collapsed?: boolean }>;
+  CollapseButton: FunctionComponent<LayoutProps>;
   Content: FunctionComponent<LayoutProps & React.RefAttributes<HTMLDivElement>>;
 } = ({ children, className }) => {
   return <div className={classNames('Layout', className)}>{children}</div>;
@@ -20,6 +21,10 @@ Layout.Sidebar = ({ children, className, collapsed = false }) => {
   ) : (
     <div className={classNames('Layout-sidebar', className)}>{children}</div>
   );
+};
+
+Layout.CollapseButton = ({ children, className }) => {
+  return <div className={classNames('Layout-collapse-button', className)}>{children}</div>;
 };
 
 Layout.Content = React.forwardRef<HTMLDivElement, LayoutProps>(({ children, className }, ref) => {

--- a/src/shared/Layout.tsx
+++ b/src/shared/Layout.tsx
@@ -8,14 +8,18 @@ export type LayoutProps = {
 };
 
 export const Layout: FunctionComponent<LayoutProps> & {
-  Sidebar: FunctionComponent<LayoutProps>;
+  Sidebar: FunctionComponent<LayoutProps & { collapsed?: boolean }>;
   Content: FunctionComponent<LayoutProps & React.RefAttributes<HTMLDivElement>>;
 } = ({ children, className }) => {
   return <div className={classNames('Layout', className)}>{children}</div>;
 };
 
-Layout.Sidebar = ({ children, className }) => {
-  return <div className={classNames('Layout-sidebar', className)}>{children}</div>;
+Layout.Sidebar = ({ children, className, collapsed = false }) => {
+  return collapsed ? (
+    <div className={classNames('Layout-sidebar-collapsed', className)}>{children}</div>
+  ) : (
+    <div className={classNames('Layout-sidebar', className)}>{children}</div>
+  );
 };
 
 Layout.Content = React.forwardRef<HTMLDivElement, LayoutProps>(({ children, className }, ref) => {


### PR DESCRIPTION
Closes #145 

This is still looking far from perfect, but I'd like to stop here and evaluate. This is using the current "custom" `Layout` component, which is also used for the Docs panel - it turned out to be less cumbersome to style than the `antd`'s `Layout`.

I also did my best to perform the css voodoo right, but might still missed a ton.

I'm also happy to stop here and give up on the collapsible nav bar, if we deem this is too messy or too rough, more than justified by the benefits of the feature.

![Screenshot from 2021-11-24 16-57-54](https://user-images.githubusercontent.com/5735525/143272237-96812f37-7f93-4cd4-a70f-a68daec6589e.png)
![Screenshot from 2021-11-24 16-57-41](https://user-images.githubusercontent.com/5735525/143272243-a5d3acf9-39a1-4737-9cd7-12970a08968c.png)

