### PR TITLE
Rename summary stats fields to indicate we add counts, not rows.

### DIFF
--- a/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
@@ -76,9 +76,9 @@ let ``Handles Preview request for counting rows`` () =
   let response = request |> mainCore
   response |> should haveSubstring "summary"
   response |> should haveSubstring "totalBuckets"
-  response |> should haveSubstring "lowCountBuckets"
-  response |> should haveSubstring "totalRows"
-  response |> should haveSubstring "lowCountRows"
+  response |> should haveSubstring "suppressedBuckets"
+  response |> should haveSubstring "totalCount"
+  response |> should haveSubstring "suppressedCount"
   response |> should haveSubstring "maxDistortion"
   response |> should haveSubstring "medianDistortion"
   response |> should haveSubstring "rows"
@@ -93,9 +93,9 @@ let ``Handles Preview request for counting entities`` () =
   let response = request |> mainCore
   response |> should haveSubstring "summary"
   response |> should haveSubstring "totalBuckets"
-  response |> should haveSubstring "lowCountBuckets"
-  response |> should haveSubstring "totalRows"
-  response |> should haveSubstring "lowCountRows"
+  response |> should haveSubstring "suppressedBuckets"
+  response |> should haveSubstring "totalCount"
+  response |> should haveSubstring "suppressedCount"
   response |> should haveSubstring "maxDistortion"
   response |> should haveSubstring "medianDistortion"
   response |> should haveSubstring "rows"
@@ -130,7 +130,7 @@ let ``Handles Preview request with custom anonParams`` () =
   let responseCustom = requestCustom |> mainCore
   // The custom anonymization params have removed suppression. Assertion checks whether
   // that's respected by the service
-  responseCustom |> should haveSubstring "\"lowCountRows\": 0"
+  responseCustom |> should haveSubstring "\"suppressedCount\": 0"
 
 [<Fact>]
 let ``Handles Export request for counting rows`` () =

--- a/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
+++ b/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
@@ -6,9 +6,9 @@ open Thoth.Json.Net
 type Summary =
   {
     TotalBuckets: int
-    LowCountBuckets: int
-    TotalRows: int
-    LowCountRows: int
+    SuppressedBuckets: int
+    TotalCount: int
+    SuppressedCount: int
     MaxDistortion: float
     MedianDistortion: float
   }

--- a/anonymizer/OpenDiffix.Service/Program.fs
+++ b/anonymizer/OpenDiffix.Service/Program.fs
@@ -98,36 +98,36 @@ let handlePreview
   let result = runQuery ledHook query inputPath anonParams
 
   let mutable totalBuckets = 0
-  let mutable lowCountBuckets = 0
-  let mutable totalRows = 0
-  let mutable lowCountRows = 0
+  let mutable suppressedBuckets = 0
+  let mutable totalCount = 0
+  let mutable suppressedCount = 0
 
   let distortions = Array.create result.Rows.Length 0.0
 
   for row in result.Rows do
     let realCount = int (unwrapCount row.[1])
     totalBuckets <- totalBuckets + 1
-    totalRows <- totalRows + realCount
+    totalCount <- totalCount + realCount
 
     if row.[0] = Boolean true then
-      lowCountBuckets <- lowCountBuckets + 1
-      lowCountRows <- lowCountRows + realCount
+      suppressedBuckets <- suppressedBuckets + 1
+      suppressedCount <- suppressedCount + realCount
     else
       let noisyCount = int (unwrapCount row.[2])
       let distortion = float (abs (noisyCount - realCount)) / float realCount
-      let anonBucket = totalBuckets - lowCountBuckets - 1
+      let anonBucket = totalBuckets - suppressedBuckets - 1
       distortions.[anonBucket] <- distortion
 
-  let anonBuckets = totalBuckets - lowCountBuckets
+  let anonBuckets = totalBuckets - suppressedBuckets
   let distortions = if anonBuckets = 0 then [| 0.0 |] else Array.truncate anonBuckets distortions
   Array.sortInPlace distortions
 
   let summary =
     {
       TotalBuckets = totalBuckets
-      LowCountBuckets = lowCountBuckets
-      TotalRows = totalRows
-      LowCountRows = lowCountRows
+      SuppressedBuckets = suppressedBuckets
+      TotalCount = totalCount
+      SuppressedCount = suppressedCount
       MaxDistortion = Array.last distortions
       MedianDistortion = distortions.[anonBuckets / 2]
     }

--- a/src/AnonymizationStep/AnonymizationStep.tsx
+++ b/src/AnonymizationStep/AnonymizationStep.tsx
@@ -33,9 +33,9 @@ type CommonProps = {
 
 const emptySummary: AnonymizationSummary = {
   totalBuckets: 0,
-  lowCountBuckets: 0,
-  totalRows: 0,
-  lowCountRows: 0,
+  suppressedBuckets: 0,
+  totalCount: 0,
+  suppressedCount: 0,
   maxDistortion: 0,
   medianDistortion: 0,
 };
@@ -46,13 +46,13 @@ function summaryDescriptions(summary: AnonymizationSummary) {
   return (
     <Descriptions className="AnonymizationSummary-descriptions" layout="vertical" bordered column={{ sm: 2, md: 4 }}>
       <Descriptions.Item label="Suppressed Count">
-        {`${summary.lowCountRows} of ${summary.totalRows} (${formatPercentage(
-          summary.lowCountRows / summary.totalRows,
+        {`${summary.suppressedCount} of ${summary.totalCount} (${formatPercentage(
+          summary.suppressedCount / summary.totalCount,
         )})`}
       </Descriptions.Item>
       <Descriptions.Item label="Suppressed Bins">
-        {`${summary.lowCountBuckets} of ${summary.totalBuckets} (${formatPercentage(
-          summary.lowCountBuckets / summary.totalBuckets,
+        {`${summary.suppressedBuckets} of ${summary.totalBuckets} (${formatPercentage(
+          summary.suppressedBuckets / summary.totalBuckets,
         )})`}
       </Descriptions.Item>
       <Descriptions.Item label="Median Distortion">{formatPercentage(summary.medianDistortion)}</Descriptions.Item>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,9 +57,9 @@ export type CountInput = 'Rows' | 'Entities';
 
 export type AnonymizationSummary = {
   totalBuckets: number;
-  lowCountBuckets: number;
-  totalRows: number;
-  lowCountRows: number;
+  suppressedBuckets: number;
+  totalCount: number;
+  suppressedCount: number;
   maxDistortion: number;
   medianDistortion: number;
 };


### PR DESCRIPTION
Since we added entity counting, the names were misleading.