### PR TITLE
Integrate DfD GUI with star bucket hook

### DIFF
--- a/anonymizer/OpenDiffix.Service.Tests/AggregationHooks.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/AggregationHooks.Tests.fs
@@ -30,155 +30,197 @@ let run hooks csv query =
   let queryContext = QueryContext.make noiselessAnonParams (csvReader csv) |> withHooks hooks
   QueryEngine.run queryContext query
 
-let runWithHook csv query =
-  run [ AggregationHooks.Led.hook ] csv query
-
-let runWithoutHook csv query = run [] csv query
-
 let rows (result: QueryEngine.QueryResult) = result.Rows
 
-let assertHookDifference csv query (diff: List<Row * Row>) =
-  let withoutHookRows = runWithoutHook csv query |> rows
-  let withHookRows = runWithHook csv query |> rows
+module LedTests =
+  let assertHookDifference csv query (diff: List<Row * Row>) =
+    let withoutHookRows = run [] csv query |> rows
+    let withHookRows = run [ AggregationHooks.Led.hook ] csv query |> rows
 
-  List.zip withoutHookRows withHookRows
-  |> List.filter (fun (left, right) -> Row.equalityComparer.Equals(left, right) |> not)
-  |> should equal diff
+    List.zip withoutHookRows withHookRows
+    |> List.filter (fun (left, right) -> Row.equalityComparer.Equals(left, right) |> not)
+    |> should equal diff
 
-let assertHookFails csv query (errorFragment: string) =
-  try
-    runWithHook csv query |> ignore
-    failwith "Expecting query to fail"
-  with
-  | ex ->
-    let str = ex.Message.ToLower()
+  let assertHookFails csv query (errorFragment: string) =
+    try
+      run [ AggregationHooks.Led.hook ] csv query |> ignore
+      failwith "Expecting query to fail"
+    with
+    | ex ->
+      let str = ex.Message.ToLower()
 
-    if str.Contains(errorFragment.ToLower()) then
-      ()
-    else
-      failwith $"Expecting error to contain '%s{errorFragment}'. Got '%s{str}' instead."
+      if str.Contains(errorFragment.ToLower()) then
+        ()
+      else
+        failwith $"Expecting error to contain '%s{errorFragment}'. Got '%s{str}' instead."
 
-let csvWithVictim =
-  """
-  dept,gender,title
-  math,m,prof
-  math,m,prof
-  math,m,prof
-  math,m,prof
-  math,f,prof
-  math,f,prof
-  math,f,prof
-  math,f,prof
-  history,m,prof
-  history,m,prof
-  history,m,prof
-  history,m,prof
-  history,f,prof
-  history,f,prof
-  history,f,prof
-  history,f,prof
-  cs,m,prof
-  cs,m,prof
-  cs,m,prof
-  cs,m,prof
-  cs,f,prof
-  """
-
-let csvWithTwoVictims = csvWithVictim + "\n" + "cs,f,prof"
-let csvWithThreeCsWomen = csvWithTwoVictims + "\n" + "cs,f,prof"
-let csvWithDifferentTitles = csvWithVictim + "\n" + "cs,f,asst"
-
-let query =
-  """
-  SELECT dept, gender, title, diffix_count(*, RowIndex), diffix_low_count(RowIndex)
-  FROM table
-  GROUP BY 1, 2, 3
-  """
-
-[<Fact>]
-let ``Merges victim bucket`` () =
-  assertHookDifference
-    csvWithVictim
-    query
-    [
-      [| String "cs"; String "m"; String "prof"; Integer 4L; Boolean false |],
-      [| String "cs"; String "m"; String "prof"; Integer 5L; Boolean false |]
-    ]
-
-[<Fact>]
-let ``Merges 2 victims with same title`` () =
-  assertHookDifference
-    csvWithTwoVictims
-    query
-    [
-      [| String "cs"; String "m"; String "prof"; Integer 4L; Boolean false |],
-      [| String "cs"; String "m"; String "prof"; Integer 6L; Boolean false |]
-    ]
-
-[<Fact>]
-let ``Does not merge high count buckets`` () =
-  assertHookDifference csvWithThreeCsWomen query []
-
-[<Fact>]
-let ``Works with count distinct`` () =
-  assertHookDifference
-    csvWithVictim
+  let csvWithVictim =
     """
-    SELECT dept, gender, title, diffix_count(distinct RowIndex, RowIndex), diffix_low_count(RowIndex)
+    dept,gender,title
+    math,m,prof
+    math,m,prof
+    math,m,prof
+    math,m,prof
+    math,f,prof
+    math,f,prof
+    math,f,prof
+    math,f,prof
+    history,m,prof
+    history,m,prof
+    history,m,prof
+    history,m,prof
+    history,f,prof
+    history,f,prof
+    history,f,prof
+    history,f,prof
+    cs,m,prof
+    cs,m,prof
+    cs,m,prof
+    cs,m,prof
+    cs,f,prof
+    """
+
+  let csvWithTwoVictims = csvWithVictim + "\n" + "cs,f,prof"
+  let csvWithThreeCsWomen = csvWithTwoVictims + "\n" + "cs,f,prof"
+  let csvWithDifferentTitles = csvWithVictim + "\n" + "cs,f,asst"
+
+  let query =
+    """
+    SELECT dept, gender, title, diffix_count(*, RowIndex), diffix_low_count(RowIndex)
     FROM table
     GROUP BY 1, 2, 3
     """
-    [
-      [| String "cs"; String "m"; String "prof"; Integer 4L; Boolean false |],
-      [| String "cs"; String "m"; String "prof"; Integer 5L; Boolean false |]
-    ]
 
-[<Fact>]
-let ``Works when low count filter is in HAVING`` () =
-  assertHookDifference
-    csvWithVictim
-    """
-    SELECT dept, gender, title, diffix_count(*, RowIndex)
-    FROM table
-    GROUP BY 1, 2, 3
-    HAVING NOT diffix_low_count(RowIndex)
-    """
-    [
-      [| String "cs"; String "m"; String "prof"; Integer 4L |],  //
-      [| String "cs"; String "m"; String "prof"; Integer 5L |]
-    ]
+  [<Fact>]
+  let ``Merges victim bucket`` () =
+    assertHookDifference
+      csvWithVictim
+      query
+      [
+        [| String "cs"; String "m"; String "prof"; Integer 4L; Boolean false |],
+        [| String "cs"; String "m"; String "prof"; Integer 5L; Boolean false |]
+      ]
 
-[<Fact>]
-let ``Requires low count filter aggregator in scope`` () =
-  assertHookFails
-    csvWithVictim
-    """
-    SELECT dept, gender, title, diffix_count(*, RowIndex)
-    FROM table
-    GROUP BY 1, 2, 3
-    """
-    "cannot find required aggregator"
+  [<Fact>]
+  let ``Merges 2 victims with same title`` () =
+    assertHookDifference
+      csvWithTwoVictims
+      query
+      [
+        [| String "cs"; String "m"; String "prof"; Integer 4L; Boolean false |],
+        [| String "cs"; String "m"; String "prof"; Integer 6L; Boolean false |]
+      ]
 
-[<Fact>]
-let ``Ignores real count`` () =
-  assertHookDifference
-    csvWithVictim
-    """
-    SELECT dept, gender, title, count(*), diffix_count(*, RowIndex), diffix_low_count(RowIndex)
-    FROM table
-    GROUP BY 1, 2, 3
-    """
-    [
-      [| String "cs"; String "m"; String "prof"; Integer 4L; Integer 4L; Boolean false |],
-      [| String "cs"; String "m"; String "prof"; Integer 4L; Integer 5L; Boolean false |]
-    ]
+  [<Fact>]
+  let ``Does not merge high count buckets`` () =
+    assertHookDifference csvWithThreeCsWomen query []
 
-[<Fact>]
-let ``Ignores global aggregation`` () =
-  assertHookDifference
-    csvWithVictim
+  [<Fact>]
+  let ``Works with count distinct`` () =
+    assertHookDifference
+      csvWithVictim
+      """
+      SELECT dept, gender, title, diffix_count(distinct RowIndex, RowIndex), diffix_low_count(RowIndex)
+      FROM table
+      GROUP BY 1, 2, 3
+      """
+      [
+        [| String "cs"; String "m"; String "prof"; Integer 4L; Boolean false |],
+        [| String "cs"; String "m"; String "prof"; Integer 5L; Boolean false |]
+      ]
+
+  [<Fact>]
+  let ``Works when low count filter is in HAVING`` () =
+    assertHookDifference
+      csvWithVictim
+      """
+      SELECT dept, gender, title, diffix_count(*, RowIndex)
+      FROM table
+      GROUP BY 1, 2, 3
+      HAVING NOT diffix_low_count(RowIndex)
+      """
+      [
+        [| String "cs"; String "m"; String "prof"; Integer 4L |],  //
+        [| String "cs"; String "m"; String "prof"; Integer 5L |]
+      ]
+
+  [<Fact>]
+  let ``Requires low count filter aggregator in scope`` () =
+    assertHookFails
+      csvWithVictim
+      """
+      SELECT dept, gender, title, diffix_count(*, RowIndex)
+      FROM table
+      GROUP BY 1, 2, 3
+      """
+      "cannot find required DiffixLowCount aggregator"
+
+  [<Fact>]
+  let ``Ignores real count`` () =
+    assertHookDifference
+      csvWithVictim
+      """
+      SELECT dept, gender, title, count(*), diffix_count(*, RowIndex), diffix_low_count(RowIndex)
+      FROM table
+      GROUP BY 1, 2, 3
+      """
+      [
+        [| String "cs"; String "m"; String "prof"; Integer 4L; Integer 4L; Boolean false |],
+        [| String "cs"; String "m"; String "prof"; Integer 4L; Integer 5L; Boolean false |]
+      ]
+
+  [<Fact>]
+  let ``Ignores global aggregation`` () =
+    assertHookDifference
+      csvWithVictim
+      """
+      SELECT diffix_count(*, RowIndex)
+      FROM table
+      """
+      []
+
+module StarBucketTests =
+  // C and D are below the default lowThresh of 3 and will be suppressed
+  let csv =
     """
-    SELECT diffix_count(*, RowIndex)
+    letter
+    A
+    A
+    A
+    B
+    B
+    B
+    C
+    C
+    D
+    """
+
+  // now only C is below the default lowThresh, and so is the *-bucket
+  let csvSuppressedStarBucket = csv.Replace("D\n", "")
+
+  let query =
+    """
+    SELECT letter, diffix_count(*, RowIndex), diffix_low_count(RowIndex)
     FROM table
+    GROUP BY 1
     """
-    []
+
+  [<Fact>]
+  let ``Counts all suppressed buckets`` () =
+    let mutable suppressedAnonCount = Null
+    let pullHookResultsCallback results = suppressedAnonCount <- results
+
+    run [ AggregationHooks.StarBucket.hook pullHookResultsCallback ] csv query
+    |> ignore
+
+    suppressedAnonCount |> should equal (Integer 3L)
+
+  [<Fact>]
+  let ``Counts all suppressed buckets, but suppresses the star bucket`` () =
+    let mutable suppressedAnonCount = Null
+    let pullHookResultsCallback results = suppressedAnonCount <- results
+
+    run [ AggregationHooks.StarBucket.hook pullHookResultsCallback ] csvSuppressedStarBucket query
+    |> ignore
+
+    suppressedAnonCount |> should equal Null

--- a/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
@@ -79,6 +79,7 @@ let ``Handles Preview request for counting rows`` () =
   response |> should haveSubstring "suppressedBuckets"
   response |> should haveSubstring "totalCount"
   response |> should haveSubstring "suppressedCount"
+  response |> should haveSubstring "suppressedAnonCount"
   response |> should haveSubstring "maxDistortion"
   response |> should haveSubstring "medianDistortion"
   response |> should haveSubstring "rows"
@@ -96,6 +97,7 @@ let ``Handles Preview request for counting entities`` () =
   response |> should haveSubstring "suppressedBuckets"
   response |> should haveSubstring "totalCount"
   response |> should haveSubstring "suppressedCount"
+  response |> should haveSubstring "suppressedAnonCount"
   response |> should haveSubstring "maxDistortion"
   response |> should haveSubstring "medianDistortion"
   response |> should haveSubstring "rows"
@@ -145,7 +147,10 @@ let ``Handles Export request for counting rows`` () =
 
   let result = System.IO.File.ReadAllLines(outputFile.Path)
   result |> should contain "\"age\",\"city\",\"count\""
-  result.Length |> should equal 2
+  // star bucket comes as first, also note we're not asserting on the count
+  // in order to not depend on data too much
+  result.[1] |> should startWith "\"*\",\"*\","
+  result.Length |> should equal 3
 
 [<Fact>]
 let ``Handles Export request for counting entities`` () =
@@ -160,7 +165,10 @@ let ``Handles Export request for counting entities`` () =
 
   let result = System.IO.File.ReadAllLines(outputFile.Path)
   result |> should contain "\"age\",\"city\",\"count\""
-  result.Length |> should equal 2
+  // star bucket comes as first, also note we're not asserting on the count
+  // in order to not depend on data too much
+  result.[1] |> should startWith "\"*\",\"*\","
+  result.Length |> should equal 3
 
 [<Fact>]
 let ``Handles Export request with custom anonParams`` () =
@@ -197,4 +205,5 @@ let ``Handles Export request with custom anonParams`` () =
   // The custom anonymization params have ridiculous suppression threshold to suppress all buckets
   // Assertion checks whether that's respected by the service
   result |> should contain "\"age\",\"city\",\"count\""
+  // 1 (only header) - the star bucket got suppressed too!
   result.Length |> should equal 1

--- a/anonymizer/OpenDiffix.Service/AggregationHooks.fs
+++ b/anonymizer/OpenDiffix.Service/AggregationHooks.fs
@@ -27,7 +27,17 @@ let private isGlobalAggregation (aggregationContext: AggregationContext) =
 let private lowCountIndex (aggregationContext: AggregationContext) =
   match findAggregator DiffixLowCount aggregationContext.Aggregators with
   | Some index -> index
-  | None -> failwith "Cannot find required aggregator for LED hook"
+  | None -> failwith "Cannot find required DiffixLowCount aggregator"
+
+let private diffixCountIndex (aggregationContext: AggregationContext) =
+  match findAggregator DiffixCount aggregationContext.Aggregators with
+  | Some index -> index
+  | None -> failwith "Cannot find required DiffixCount aggregator"
+
+let private countIndex (aggregationContext: AggregationContext) =
+  match findAggregator Count aggregationContext.Aggregators with
+  | Some index -> index
+  | None -> failwith "Cannot find required Count aggregator"
 
 module Led =
   type private SiblingPerColumn =
@@ -168,6 +178,7 @@ module StarBucket =
   let private computeStarBucket callback aggregationContext buckets =
     let starBucket = makeStarBucket aggregationContext
     let lowCountIndex = lowCountIndex aggregationContext
+    let diffixCountIndex = diffixCountIndex aggregationContext
 
     let buckets =
       buckets
@@ -181,7 +192,22 @@ module StarBucket =
           bucket |> mergeAllAggregatorsInto starBucket
       )
 
-    callback starBucket
+    let executionContext = starBucket.ExecutionContext
+
+    // NOTE this is also true when there is no star bucket (no suppression)
+    //      this is because of how the initial value (`null`) of the
+    //      `DiffixLowCount` aggregator is translated to `Boolean true`
+    let isStarBucketLowCount =
+      starBucket.Aggregators.[lowCountIndex].Final(executionContext)
+      |> Value.unwrapBoolean
+
+    let starBucketResults =
+      if isStarBucketLowCount then
+        Null
+      else
+        starBucket.Aggregators.[diffixCountIndex].Final(executionContext)
+
+    callback starBucketResults
     buckets :> Bucket seq
 
   let hook callback (aggregationContext: AggregationContext) (buckets: Bucket seq) =

--- a/anonymizer/OpenDiffix.Service/AggregationHooks.fs
+++ b/anonymizer/OpenDiffix.Service/AggregationHooks.fs
@@ -201,13 +201,13 @@ module StarBucket =
       starBucket.Aggregators.[lowCountIndex].Final(executionContext)
       |> Value.unwrapBoolean
 
-    let starBucketResults =
+    let suppressedAnonCount =
       if isStarBucketLowCount then
         Null
       else
         starBucket.Aggregators.[diffixCountIndex].Final(executionContext)
 
-    callback starBucketResults
+    callback suppressedAnonCount
     buckets :> Bucket seq
 
   let hook callback (aggregationContext: AggregationContext) (buckets: Bucket seq) =

--- a/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
+++ b/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
@@ -9,6 +9,7 @@ type Summary =
     SuppressedBuckets: int
     TotalCount: int
     SuppressedCount: int
+    SuppressedAnonCount: int option
     MaxDistortion: float
     MedianDistortion: float
   }
@@ -65,6 +66,11 @@ type Request =
   | Export of ExportRequest
   | HasMissingValues of HasMissingValuesRequest
 
+let private encodeIntOption =
+  function
+  | Some int -> Encode.int int
+  | None -> Encode.nil
+
 let rec private encodeValue =
   function
   | Null -> Encode.nil
@@ -91,6 +97,7 @@ let private extraCoders =
   Extra.empty
   |> Extra.withCustom encodeType generateDecoder<ExpressionType>
   |> Extra.withCustom encodeValue generateDecoder<Value>
+  |> Extra.withCustom encodeIntOption generateDecoder<int option>
 
 let private decodeType request =
   Decode.Auto.unsafeFromString (request, caseStrategy = CamelCase, extra = extraCoders)

--- a/src/AnonymizationStep/AnonymizationStep.tsx
+++ b/src/AnonymizationStep/AnonymizationStep.tsx
@@ -36,6 +36,7 @@ const emptySummary: AnonymizationSummary = {
   suppressedBuckets: 0,
   totalCount: 0,
   suppressedCount: 0,
+  suppressedAnonCount: null,
   maxDistortion: 0,
   medianDistortion: 0,
 };

--- a/src/AnonymizationStep/AnonymizedResultsTable.tsx
+++ b/src/AnonymizationStep/AnonymizedResultsTable.tsx
@@ -130,7 +130,7 @@ function filterRows(mode: DisplayMode, rows: AnonymizedResultRow[]) {
   }
 }
 
-function addValue(rowData: TableRowData, values: AnonymizedValue[]) {
+function addValuesToRowData(rowData: TableRowData, values: AnonymizedValue[]) {
   const { length } = values;
   for (let columnIdx = 0; columnIdx < length; columnIdx++) {
     const value = values[columnIdx];
@@ -150,7 +150,7 @@ function mapRow(row: AnonymizedResultRow, i: number) {
     lowCount: row.lowCount,
   };
 
-  addValue(rowData, row.values);
+  addValuesToRowData(rowData, row.values);
 
   return rowData;
 }
@@ -171,7 +171,7 @@ function makeSuppressBinData(result: AnonymizedQueryResult) {
         : '*',
     );
 
-    addValue(rowData, values);
+    addValuesToRowData(rowData, values);
     return [rowData];
   } else {
     // no suppression took place _OR_ the suppress bin was itself suppressed by the

--- a/src/AnonymizationStep/AnonymizedResultsTable.tsx
+++ b/src/AnonymizationStep/AnonymizedResultsTable.tsx
@@ -11,6 +11,7 @@ import {
   RowData,
   Value,
   BucketColumn,
+  AnonymizedValue,
 } from '../types';
 import { DisplayModeSwitch } from './DisplayModeSwitch';
 
@@ -97,22 +98,23 @@ function makeColumnData(title: string, dataIndex: string, type: ColumnType, rend
 
 const AGG_COLUMN_TYPE = 'real';
 
-const mapColumn = (mode: DisplayMode, bucketColumns: BucketColumn[]) => (column: AnonymizedResultColumn, i: number) => {
-  if (column.type === 'aggregate') {
-    switch (mode) {
-      case 'anonymized':
-        return [makeColumnData(column.name, i + '_anon', AGG_COLUMN_TYPE, renderValue)];
-      case 'combined':
-        return [
-          makeColumnData(column.name + ' (anonymized)', i + '_anon', AGG_COLUMN_TYPE, renderLowCountValue),
-          makeColumnData(column.name + ' (original)', i + '_real', AGG_COLUMN_TYPE, renderValue),
-          makeColumnData('Distortion', i + '_diff', 'real', renderRelativeNoiseValue),
-        ];
+const mapColumn =
+  (mode: DisplayMode, bucketColumns: BucketColumn[]) => (column: AnonymizedResultColumn, columnIdx: number) => {
+    if (column.type === 'aggregate') {
+      switch (mode) {
+        case 'anonymized':
+          return [makeColumnData(column.name, columnIdx + '_anon', AGG_COLUMN_TYPE, renderValue)];
+        case 'combined':
+          return [
+            makeColumnData(column.name + ' (anonymized)', columnIdx + '_anon', AGG_COLUMN_TYPE, renderLowCountValue),
+            makeColumnData(column.name + ' (original)', columnIdx + '_real', AGG_COLUMN_TYPE, renderValue),
+            makeColumnData('Distortion', columnIdx + '_diff', 'real', renderRelativeNoiseValue),
+          ];
+      }
     }
-  }
 
-  return [makeColumnData(column.name, i.toString(), column.type, buildCellRenderer(column, bucketColumns))];
-};
+    return [makeColumnData(column.name, columnIdx.toString(), column.type, buildCellRenderer(column, bucketColumns))];
+  };
 
 // Rows
 
@@ -128,26 +130,54 @@ function filterRows(mode: DisplayMode, rows: AnonymizedResultRow[]) {
   }
 }
 
+function addValue(rowData: TableRowData, values: AnonymizedValue[]) {
+  const { length } = values;
+  for (let columnIdx = 0; columnIdx < length; columnIdx++) {
+    const value = values[columnIdx];
+    if (value && typeof value === 'object') {
+      rowData[columnIdx + '_real'] = value.realValue;
+      rowData[columnIdx + '_anon'] = value.anonValue;
+      rowData[columnIdx + '_diff'] = relativeNoise(value);
+    } else {
+      rowData[columnIdx] = value;
+    }
+  }
+}
+
 function mapRow(row: AnonymizedResultRow, i: number) {
   const rowData: TableRowData = {
     key: i,
     lowCount: row.lowCount,
   };
 
-  const { values } = row;
-  const { length } = values;
-  for (let i = 0; i < length; i++) {
-    const value = values[i];
-    if (value && typeof value === 'object') {
-      rowData[i + '_real'] = value.realValue;
-      rowData[i + '_anon'] = value.anonValue;
-      rowData[i + '_diff'] = relativeNoise(value);
-    } else {
-      rowData[i] = value;
-    }
-  }
+  addValue(rowData, row.values);
 
   return rowData;
+}
+
+function makeSuppressBinData(result: AnonymizedQueryResult) {
+  if (result.summary.suppressedAnonCount) {
+    const rowData: TableRowData = {
+      key: -1,
+      // non-null `suppressedAnonCount` implies this
+      lowCount: false,
+    };
+
+    const values: AnonymizedValue[] = result.columns.map((column: AnonymizedResultColumn) =>
+      // This TableRowData is for the suppress bin, so all bucket columns hold
+      // the star "*", while aggregate columns (counts) are coming from the summary
+      column.type === 'aggregate'
+        ? { realValue: result.summary.suppressedCount, anonValue: result.summary.suppressedAnonCount }
+        : '*',
+    );
+
+    addValue(rowData, values);
+    return [rowData];
+  } else {
+    // no suppression took place _OR_ the suppress bin was itself suppressed by the
+    // low count filter
+    return [];
+  }
 }
 
 // Component
@@ -166,7 +196,11 @@ export const AnonymizedResultsTable: FunctionComponent<AnonymizedResultsTablePro
   const [mode, setMode] = useState<DisplayMode>('anonymized');
 
   const columns = result.columns.flatMap(mapColumn(mode, bucketColumns));
-  const data = filterRows(mode, result.rows).map(mapRow);
+  const queryData = filterRows(mode, result.rows).map(mapRow);
+
+  const suppressBinData: TableRowData[] = mode === 'anonymized' ? makeSuppressBinData(result) : [];
+
+  const data = suppressBinData.concat(queryData);
 
   return (
     <div className={`AnonymizedResultsTable ${mode}`}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,6 +60,7 @@ export type AnonymizationSummary = {
   suppressedBuckets: number;
   totalCount: number;
   suppressedCount: number;
+  suppressedAnonCount: number | null;
   maxDistortion: number;
   medianDistortion: number;
 };


### PR DESCRIPTION
Closes #250 

There's a number of things to fix after this, but I'd like to postpone until next PR(s), so that this doesn't bloat infinitely:
- [ ] have more tests for `AggregationHooks` for the StarBucket hook, mainly add a test on the interaction between led and star bucket hooks (merged buckets don't end up in the star bucket)
- [ ] refactor the tests/code of the `AggregationHooks` into separate files + `Utils.fs` (which Edon is working on)
- [ ] implement the extension discussed on slack, whereby we'll include `SuppressedAnonLowCount: true | false | null` field in the summary returned from the `StarBucket` hook and the `OpenDiffix.Service` `Summary` JSON. I decided to postpone this, as this might require a non-trivial change to `reference`. I'll make a separate optional PR/issue for that.
- [ ] also #289 , point 2 and seeding spec are not yet observed