### PR TITLE
Fix bug and standardize code for numeric inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Merge suppressed buckets into a special *-bucket.
 - Added support for simple low-effect detection (LED).
+- Fixed decimal form inputs causing anonymization failure.
 
 ### Version 0.4.0
 

--- a/src/AnonParamsSelectionStep/AnonParamsSelectionStep.tsx
+++ b/src/AnonParamsSelectionStep/AnonParamsSelectionStep.tsx
@@ -35,19 +35,17 @@ export const AnonParamsSelectionStep: FunctionComponent<AnonParamsSelectionStepP
         <NotebookNavAnchor step={NotebookNavStep.AnonParamsSelection} status="done" />
         <Title level={3}>Adjust suppression threshold</Title>
 
-        <Form layout="inline">
+        <Form
+          layout="inline"
+          initialValues={{ lowThreshold: lowThreshold }}
+          onValuesChange={({ lowThreshold }) => setLowThreshold(lowThreshold)}
+        >
           <Form.Item
             label="Suppression Threshold"
             tooltip="Bins with fewer protected entities than this are suppressed. Bins with more may not be suppressed"
             name="lowThreshold"
           >
-            <InputNumber
-              size="middle"
-              min={minLowThreshold}
-              defaultValue={lowThreshold}
-              value={lowThreshold}
-              onChange={(newThreshold) => setLowThreshold(newThreshold)}
-            />
+            <InputNumber size="middle" min={minLowThreshold} />
           </Form.Item>
         </Form>
       </div>

--- a/src/AnonParamsSelectionStep/AnonParamsSelectionStep.tsx
+++ b/src/AnonParamsSelectionStep/AnonParamsSelectionStep.tsx
@@ -38,14 +38,19 @@ export const AnonParamsSelectionStep: FunctionComponent<AnonParamsSelectionStepP
         <Form
           layout="inline"
           initialValues={{ lowThreshold: lowThreshold }}
-          onValuesChange={({ lowThreshold }) => setLowThreshold(lowThreshold)}
+          onValuesChange={({ lowThreshold }) => setLowThreshold(Math.round(lowThreshold))}
         >
           <Form.Item
             label="Suppression Threshold"
             tooltip="Bins with fewer protected entities than this are suppressed. Bins with more may not be suppressed"
             name="lowThreshold"
           >
-            <InputNumber size="middle" min={minLowThreshold} />
+            <InputNumber
+              // `precision` and `Math.round` in change handler both needed to protect from decimals
+              precision={0}
+              size="middle"
+              min={minLowThreshold}
+            />
           </Form.Item>
         </Form>
       </div>

--- a/src/ColumnSelectionStep/ColumnSelectionStep.tsx
+++ b/src/ColumnSelectionStep/ColumnSelectionStep.tsx
@@ -97,21 +97,25 @@ function GeneralizationControls({
           <Form.Item label="Substring start" name="substringStart">
             <span key={column.resetCount}>
               <InputNumber
+                // `precision` and `Math.round` in change handler both needed to protect from decimals
+                precision={0}
                 size="small"
                 placeholder="1"
                 min={1}
                 value={column.substringStart as number}
-                onChange={(substringStart) => updateColumn({ substringStart })}
+                onChange={(substringStart) => updateColumn({ substringStart: Math.round(substringStart) })}
               />
             </span>
           </Form.Item>
           <Form.Item label="Substring length" name="substringLength">
             <span key={column.resetCount}>
               <InputNumber
+                // `precision` and `Math.round` in change handler both needed to protect from decimals
+                precision={0}
                 size="small"
                 min={1}
                 value={column.substringLength as number}
-                onChange={(substringLength) => updateColumn({ substringLength })}
+                onChange={(substringLength) => updateColumn({ substringLength: Math.round(substringLength) })}
               />
             </span>
           </Form.Item>


### PR DESCRIPTION
This PR does two things

1/ Closes #279 

It seems [using `initialValues` and `onValuesChange` on a `Form` component is the standard way](https://ant.design/components/form/#Why-is-component-defaultValue-not-working-when-inside-Form.Item). This gives us correct behavior of the Suppression Threshold input box's value

**NOTE** I tried to conform to this pattern in `ColumnSelectionStep` to no avail - something makes it behave funky, if we use this pattern. But since that in turn doesn't require `defaultValue` like the Suppression Threshold, I think it's best to keep as is

2/ as a bonus it fixes a bug, whereby if you input a decimal (`2.5`) in one of the available fields requiring an integer (Suppression Threshold, Substring start or Substring length), it will result in failed anonymization with a large :red_circle:. The fix causes it to round the inputs from the user and also keep things consistent in the UI. It's not super elegant, but out of number of things I've tried, only this works 100%.

