### PR TITLE
Refactor AnonymizedResultsTable row and column types

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,4 +1,4 @@
-import { AnonymizedAggregate, ColumnType, ComputedData, RowData, Task, Value } from '../types';
+import { ColumnType, ComputedData, RowData, Task, Value } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const inProgressState: ComputedData<any> = { state: 'in_progress' };
@@ -23,7 +23,7 @@ export function formatPercentage(value: number, precision = 2): string {
   return `${Math.round(factor * 100 * value) / factor}%`;
 }
 
-export function relativeNoise({ anonValue, realValue }: AnonymizedAggregate): number | null {
+export function relativeNoise(anonValue: number | null, realValue: number): number | null {
   if (anonValue === null) return null;
   return Math.abs(realValue - anonValue) / realValue;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,7 @@ export type ComputedData<T> =
 export type DisplayMode = 'anonymized' | 'combined';
 
 export type RowData = {
-  [dataIndex in number | string]: Value;
+  [dataIndex: string]: Value;
 };
 
 // Schema
@@ -103,13 +103,13 @@ export type AnonymizedResultColumn = {
 
 export type AnonymizedColumnType = ColumnType | 'aggregate';
 
-export type AnonymizedResultRow = { lowCount: boolean; values: AnonymizedValue[] };
-
-export type AnonymizedValue = Value | AnonymizedAggregate;
-
-export type AnonymizedAggregate = {
-  realValue: number;
-  anonValue: number | null;
+// Represents row data returned from the preview query request to the
+// `OpenDiffix.Service`
+export type AnonymizedResultRow = {
+  lowCount: boolean;
+  count: number;
+  diffixCount: number | null;
+  bucketValues: RowData;
 };
 
 // AnonymizationParams


### PR DESCRIPTION
When doing #290 I found it a bit hard to "match" the row data structure with the one required by the column-building function. I was constantly getting `undefined has no toString field` errors, because I was fetching `2_anon` instead of `3_anon` field, for example.

This was mostly caused by the "loose" indexing by column index, which trickled down from the "raw" query result coming from the `OpenDiffix.Service`.

This PR attempts to fix this, by aligning the row types:
1/ raw row comes from the service and is transformed to a "named" structure `AnonymizedResultRow` as soon as possible
2/ that structure is next explicitly translated to a "flat" `TableRowData`, which the table renderer will understand. I've added some comments also, which I would find helpful when doing #290.

