### PR TITLE
Make AnonymizedResultTable data indices slightly more typesafe

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,4 +1,4 @@
-import { AnonymizedAggregate, ColumnType, ComputedData, RowData, Task, Value } from '../types';
+import { AnonymizedAggregate, ColumnType, RowDataIndex, ComputedData, RowData, Task, Value } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const inProgressState: ComputedData<any> = { state: 'in_progress' };
@@ -49,7 +49,7 @@ function toBoolean(value: Value) {
 }
 
 export const columnSorter =
-  (type: ColumnType, dataIndex: number | string) =>
+  (type: ColumnType, dataIndex: RowDataIndex) =>
   (rowA: RowData, rowB: RowData): number => {
     let a = rowA[dataIndex];
     let b = rowB[dataIndex];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,8 +10,11 @@ export type ComputedData<T> =
 
 export type DisplayMode = 'anonymized' | 'combined';
 
+export type AggregateRowDataIndex = `${number}_anon` | `${number}_real` | `${number}_diff`;
+export type RowDataIndex = number | AggregateRowDataIndex;
+
 export type RowData = {
-  [dataIndex in number | string]: Value;
+  [dataIndex: RowDataIndex]: Value;
 };
 
 // Schema


### PR DESCRIPTION
Supersedes #292. This doesn't fix the discrepancy of the numeric indexing of columns between the returned rows from `Service` and the displayed table, but should make it easier to associate one with the other (and harder to get it wrong).

Kudos to Edon for suggesting the type-template