### PR TITLE
Conform to suppression bin specs

### DIFF
--- a/anonymizer/OpenDiffix.Service/AggregationHooks.fs
+++ b/anonymizer/OpenDiffix.Service/AggregationHooks.fs
@@ -148,11 +148,10 @@ module StarBucket =
   let private makeStarBucket (aggregationContext: AggregationContext) =
     let isGlobal = isGlobalAggregation aggregationContext
 
-    // TODO: Do we need a specific noise seed for the star bucket?
     let executionContext = aggregationContext.ExecutionContext
 
-    // Group labels are all NULLs
-    let group = Array.create aggregationContext.GroupingLabels.Length Null
+    // Group labels are all '*'s
+    let group = Array.create aggregationContext.GroupingLabels.Length (String "*")
 
     let aggregators =
       aggregationContext.Aggregators

--- a/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
+++ b/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
@@ -9,6 +9,7 @@ type Summary =
     SuppressedBuckets: int
     TotalCount: int
     SuppressedCount: int
+    // `None` if the suppress bin has been suppressed
     SuppressedAnonCount: int option
     MaxDistortion: float
     MedianDistortion: float

--- a/anonymizer/OpenDiffix.Service/Program.fs
+++ b/anonymizer/OpenDiffix.Service/Program.fs
@@ -56,8 +56,7 @@ let csvFormatter suppressedAnonCount result =
     |> List.map (fun row -> row |> Array.map csvFormat |> String.join ",")
 
   match suppressedAnonCount with
-  // no suppression took place _OR_ the suppress bin was itself suppressed by the
-  // low count filter
+  // no suppression took place _OR_ the suppress bin was itself suppressed
   | Null -> header :: rows |> String.join "\n"
   // there was suppression and the suppress bin wasn't suppressed
   | Integer _ -> header :: starBucketRow :: rows |> String.join "\n"

--- a/src/AnonymizationStep/AnonymizedResultsTable.tsx
+++ b/src/AnonymizationStep/AnonymizedResultsTable.tsx
@@ -186,7 +186,7 @@ function makeSuppressBinData(result: AnonymizedQueryResult) {
     const values: AnonymizedValue[] = result.columns.map((column: AnonymizedResultColumn) =>
       // This TableRowData is for the suppress bin, so all bucket columns hold
       // the star "*", while aggregate columns (counts) are coming from the summary
-      column.type === 'aggregate'
+      column.type === 'aggregate' && column.name === 'Count'
         ? { realValue: result.summary.suppressedCount, anonValue: result.summary.suppressedAnonCount }
         : '*',
     );
@@ -194,8 +194,7 @@ function makeSuppressBinData(result: AnonymizedQueryResult) {
     addValuesToRowData(rowData, values);
     return [rowData];
   } else {
-    // no suppression took place _OR_ the suppress bin was itself suppressed by the
-    // low count filter
+    // no suppression took place _OR_ the suppress bin was itself suppressed
     return [];
   }
 }


### PR DESCRIPTION
Closes #289 

Starting as draft b/c the `reference` update is required, but not yet merged into master.

This PR is for two independent changes, see commits.

Also, I'm abandoning the idea to "expand" the `OpenDiffix.Service` Summary field by `SuppressedAnonLowCount: boolean` or any other changes like this. The reason is the following - we have added a next rule about the suppress bin (we don't show it if it is built out of just one suppressed bucket). Now, these rules are complex enough, that we can say that it is `Service`, which should only be responsible for releasing (or not) of the *-bucket. It will only serve `SuppressedAnonCount: int option`, and if it's `None`, then it means that _for some reason_, the *-bucket may not be published. This decision is abstracted out of the clients (CSV export and DfD GUI).

