### PR TITLE
Document and explain the suppress bin

### DIFF
--- a/docs/operation.md
+++ b/docs/operation.md
@@ -219,7 +219,7 @@ The combined view lets you examine precisely the distortion and suppression. The
 
 ### Suppress bin
 
-The first row in the Anonymized Data table might contain the _suppress bin_, which provides the anonymized count of the data from the bins which got suppressed. The suppress bin has all of the columns selected for anonymization displaying the value `*`.
+The first row in the Anonymized Data table might contain the _suppress bin_, which provides the combined anonymized count of all the bins that were suppressed. The suppress bin shows all column values as `*`.
 
 Note that the suppress bin may itself be suppressed. The suppress bin is only shown in the `Anonymized` view.
 

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -217,6 +217,12 @@ The combined view displays suppressed bins. The `Count (anonymized)` column is l
 
 The combined view lets you examine precisely the distortion and suppression. The anonymized data can be sorted by each column. Sorting by `Count (original)` shows the ascending suppressed bins first, and so is useful for examining what has been suppressed. Sorting by `Distortion` descending shows the bins with the most error first, and so is useful for examining which bins have high distortion.
 
+### Suppress bin
+
+The first row in the Anonymized Data table might contain the _suppress bin_, which provides the anonymized count of the data from the bins which got suppressed. The suppress bin has all of the columns selected for anonymization displaying the value `*`.
+
+Note that the suppress bin may itself be suppressed. The suppress bin is only shown in the `Anonymized` view.
+
 ### What is safe to release
 
 Note that the data in the `Anonymized` view is the only data that is properly anonymized by __Diffix for Desktop__. Note in particular that the Anonymization Summary is not anonymized per se. See [Releasing Anonymization Summary statistics](tips.md#releasing-anonymization-summary-statistics).

--- a/src/AnonymizationStep/AnonymizedResultsTable.tsx
+++ b/src/AnonymizationStep/AnonymizedResultsTable.tsx
@@ -191,6 +191,9 @@ function makeSuppressBinData(result: AnonymizedQueryResult) {
         : '*',
     );
 
+    const firstStarInRowIdx = values.findIndex((v) => v === '*');
+    if (firstStarInRowIdx > -1) values[firstStarInRowIdx] = '* (Suppress bin)';
+
     addValuesToRowData(rowData, values);
     return [rowData];
   } else {

--- a/src/Notebook/notebook-help.tsx
+++ b/src/Notebook/notebook-help.tsx
@@ -127,8 +127,8 @@ function AnonymizedResultsHelp() {
         <DocsLink page="operation" section="suppress-bin">
           suppress bin
         </DocsLink>{' '}
-        comprised of all the bins which got suppressed, is shown first, denoted by <Text code>*</Text>
-        values in all the anonymized columns.
+        denoted by <Text code>*</Text> column values, is shown first. It indicates the combined anonymized count of all
+        suppressed bins.
       </Paragraph>
     </div>
   );
@@ -139,8 +139,8 @@ function CsvExportHelp() {
     <div>
       <Title level={4}>CSV Export</Title>
       <Paragraph>
-        Exports the anonymized results only (not the combined view). The suppress bin is exported as first row in the
-        CSV file, unless it has been suppressed.
+        Exports the anonymized results only (not the combined view). The suppress bin is exported as the first row in
+        the CSV file, unless it has been suppressed.
       </Paragraph>
     </div>
   );

--- a/src/Notebook/notebook-help.tsx
+++ b/src/Notebook/notebook-help.tsx
@@ -122,6 +122,14 @@ function AnonymizedResultsHelp() {
           Click here for details.
         </DocsLink>
       </Paragraph>
+      <Paragraph>
+        The{' '}
+        <DocsLink page="operation" section="suppress-bin">
+          suppress bin
+        </DocsLink>{' '}
+        comprised of all the bins which got suppressed, is shown first, denoted by <Text code>*</Text>
+        values in all the anonymized columns.
+      </Paragraph>
     </div>
   );
 }
@@ -130,7 +138,10 @@ function CsvExportHelp() {
   return (
     <div>
       <Title level={4}>CSV Export</Title>
-      <Paragraph>Exports the anonymized results only (not the combined view).</Paragraph>
+      <Paragraph>
+        Exports the anonymized results only (not the combined view). The suppress bin is exported as first row in the
+        CSV file, unless it has been suppressed.
+      </Paragraph>
     </div>
   );
 }


### PR DESCRIPTION
Adds docs to the side panel and markdown.

I also took a stab at adding a tooltip to the suppress bin "*"-values in the table. I didn't like the result - the code was ugly and it also didn't behave well (one needs to hover exactly over the * to display the tooltip). So I came up with this dumber but straightforward way:

![Screenshot from 2021-12-14 09-42-02](https://user-images.githubusercontent.com/5735525/145963477-fc338beb-4bb4-4774-abc3-e74593d8c4de.png)