### PR TITLE
Star bucket cleanups and extra tests

### DIFF
--- a/anonymizer/OpenDiffix.Service.Tests/Led.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/Led.Tests.fs
@@ -151,3 +151,13 @@ let ``Ignores global aggregation`` () =
     FROM table
     """
     []
+
+[<Fact>]
+let ``Ignores if the victim cannot be singled out`` () =
+  assertHookDifference
+    csvWithDifferentTitles
+    """
+    SELECT diffix_count(*, RowIndex)
+    FROM table
+    """
+    []

--- a/anonymizer/OpenDiffix.Service/AggregationHooks.fs
+++ b/anonymizer/OpenDiffix.Service/AggregationHooks.fs
@@ -190,7 +190,7 @@ module StarBucket =
       |> Value.unwrapBoolean
 
     let suppressedAnonCount =
-      // NOTE: we can have a suppress bin consisting of a single suppressed bucket,
+      // NOTE: we can have a star bucket consisting of a single suppressed bucket,
       // which won't be suppressed by itself (different noise seed). In such case,
       // we must enforce the suppression manually.
       if isStarBucketLowCount || bucketsInStarBucket < 2 then

--- a/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
+++ b/anonymizer/OpenDiffix.Service/JsonEncodersDecoders.fs
@@ -9,7 +9,7 @@ type Summary =
     SuppressedBuckets: int
     TotalCount: int
     SuppressedCount: int
-    // `None` if the suppress bin has been suppressed
+    // `None` if the star bucket has been suppressed
     SuppressedAnonCount: int option
     MaxDistortion: float
     MedianDistortion: float

--- a/anonymizer/OpenDiffix.Service/Program.fs
+++ b/anonymizer/OpenDiffix.Service/Program.fs
@@ -55,9 +55,9 @@ let csvFormatter suppressedAnonCount result =
     |> List.map (fun row -> row |> Array.map csvFormat |> String.join ",")
 
   match suppressedAnonCount with
-  // no suppression took place _OR_ the suppress bin was itself suppressed
+  // no suppression took place _OR_ the star bucket was itself suppressed
   | Null -> header :: rows |> String.join "\n"
-  // there was suppression and the suppress bin wasn't suppressed
+  // there was suppression and the star bucket wasn't suppressed
   | Integer _ -> header :: starBucketRow :: rows |> String.join "\n"
   | _ -> failwith "Unexpected value of SuppressedAnonCount"
 

--- a/anonymizer/OpenDiffix.Service/StarBucket.fs
+++ b/anonymizer/OpenDiffix.Service/StarBucket.fs
@@ -53,7 +53,7 @@ let hook callback (aggregationContext: AggregationContext) (buckets: Bucket seq)
     |> Value.unwrapBoolean
 
   let suppressedAnonCount =
-    // NOTE: we can have a suppress bin consisting of a single suppressed bucket,
+    // NOTE: we can have a star bucket consisting of a single suppressed bucket,
     // which won't be suppressed by itself (different noise seed). In such case,
     // we must enforce the suppression manually.
     if isStarBucketLowCount || bucketsInStarBucket < 2 then


### PR DESCRIPTION
This is a rather loose collection of commits, as explained in their titles. Review by commit pls.

The commit which changes naming - I now agree that changing to `bin` / `suppress bin` in the code would be overkill, the `Bucket` name is all over the `reference`. Instead, I want to keep it consistently named `star bucket` in all code and `suppress bin` externally, so this commit amends a couple of places where `suppress bin` crept into the code & comments

