### PR TITLE
Make renderers aware of the special case of a *-bucket value

### DIFF
--- a/src/AnonymizationStep/AnonymizedResultsTable.tsx
+++ b/src/AnonymizationStep/AnonymizedResultsTable.tsx
@@ -64,7 +64,7 @@ function renderValue(v: Value) {
   }
 }
 
-function renderBucketValue(column: AnonymizedResultColumn, bucketColumns: BucketColumn[]) {
+function renderBucketColumnValue(column: AnonymizedResultColumn, bucketColumns: BucketColumn[]) {
   const bucketColumn = bucketColumns.find((c) => c.name === column.name);
   return (v: Value, row: TableRowData) => {
     // see note on `ellipsis` above
@@ -127,7 +127,7 @@ const mapColumn =
       }
     }
 
-    return [makeColumnData(column.name, columnIdx, column.type, renderBucketValue(column, bucketColumns))];
+    return [makeColumnData(column.name, columnIdx, column.type, renderBucketColumnValue(column, bucketColumns))];
   };
 
 // Rows

--- a/src/AnonymizationStep/AnonymizedResultsTable.tsx
+++ b/src/AnonymizationStep/AnonymizedResultsTable.tsx
@@ -56,19 +56,6 @@ function numericRangeCell(binSize: number, v: number) {
   return <Tooltip title={tooltip}>{v}</Tooltip>;
 }
 
-function valueCell(bucketColumn: BucketColumn | undefined, v: number | boolean | string, isStarBucketRow: boolean) {
-  if (
-    bucketColumn &&
-    (bucketColumn.type === 'integer' || bucketColumn.type === 'real') &&
-    bucketColumn.generalization &&
-    !isStarBucketRow
-  ) {
-    return numericRangeCell(bucketColumn.generalization.binSize, v as number);
-  } else {
-    return plainStringCell(v.toString());
-  }
-}
-
 function renderValue(v: Value) {
   if (v === null) {
     return nullCell();
@@ -77,14 +64,23 @@ function renderValue(v: Value) {
   }
 }
 
-function buildCellRenderer(column: AnonymizedResultColumn, bucketColumns: BucketColumn[]) {
+function renderBucketValue(column: AnonymizedResultColumn, bucketColumns: BucketColumn[]) {
   const bucketColumn = bucketColumns.find((c) => c.name === column.name);
   return (v: Value, row: TableRowData) => {
     // see note on `ellipsis` above
     if (v === null) {
       return nullCell();
     } else {
-      return valueCell(bucketColumn, v, row.isStarBucketRow);
+      if (
+        bucketColumn &&
+        (bucketColumn.type === 'integer' || bucketColumn.type === 'real') &&
+        bucketColumn.generalization &&
+        !row.isStarBucketRow
+      ) {
+        return numericRangeCell(bucketColumn.generalization.binSize, v as number);
+      } else {
+        return plainStringCell(v.toString());
+      }
     }
   };
 }
@@ -131,7 +127,7 @@ const mapColumn =
       }
     }
 
-    return [makeColumnData(column.name, columnIdx, column.type, buildCellRenderer(column, bucketColumns))];
+    return [makeColumnData(column.name, columnIdx, column.type, renderBucketValue(column, bucketColumns))];
   };
 
 // Rows

--- a/src/AnonymizationStep/AnonymizedResultsTable.tsx
+++ b/src/AnonymizationStep/AnonymizedResultsTable.tsx
@@ -56,11 +56,12 @@ function numericRangeCell(binSize: number, v: number) {
   return <Tooltip title={tooltip}>{v}</Tooltip>;
 }
 
-function valueCell(bucketColumn: BucketColumn | undefined, v: number | boolean | string) {
+function valueCell(bucketColumn: BucketColumn | undefined, v: number | boolean | string, isStarBucketRow: boolean) {
   if (
     bucketColumn &&
     (bucketColumn.type === 'integer' || bucketColumn.type === 'real') &&
-    bucketColumn.generalization
+    bucketColumn.generalization &&
+    !isStarBucketRow
   ) {
     return numericRangeCell(bucketColumn.generalization.binSize, v as number);
   } else {
@@ -78,12 +79,12 @@ function renderValue(v: Value) {
 
 function buildCellRenderer(column: AnonymizedResultColumn, bucketColumns: BucketColumn[]) {
   const bucketColumn = bucketColumns.find((c) => c.name === column.name);
-  return (v: Value) => {
+  return (v: Value, row: TableRowData) => {
     // see note on `ellipsis` above
     if (v === null) {
       return nullCell();
     } else {
-      return valueCell(bucketColumn, v);
+      return valueCell(bucketColumn, v, row.isStarBucketRow);
     }
   };
 }
@@ -102,7 +103,7 @@ function makeColumnData(
   title: string,
   dataIndex: RowDataIndex,
   type: ColumnType,
-  render: (v: Value) => React.ReactNode,
+  render: (v: Value, row: TableRowData) => React.ReactNode,
 ) {
   return {
     title,


### PR DESCRIPTION
Closes #301 

I had a fix implemented already, as it is the alternative *-bucket tooltip code. Instead of manipulating the *-bucket strings by hand, we make the code aware of the special nature of the *-bucket cell value.

~I rejected this version earlier, but now, it seems much more appealing. However, I'm not entirely sure I like this code, let me know if it is too bad, I'll look for alternatives.~

EDIT: the above line and the original screenshot were outdated. Here's the behavior that this PR provides now (same as before, just the tooltip is fixed): 
![Screenshot from 2022-01-04 09-53-07](https://user-images.githubusercontent.com/5735525/148033786-0a1b8c10-8398-4504-b25e-a749e7374c1f.png)

