### PR TITLE
Fix tests using test data from `reference`

### DIFF
--- a/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
@@ -20,7 +20,7 @@ let private defaultAnonParams =
   """
   {
     "suppression": {
-      "lowThreshold": 3,
+      "lowThreshold": 2,
       "layerSD": 1,
       "lowMeanGap": 2
     },
@@ -150,7 +150,8 @@ let ``Handles Export request for counting rows`` () =
   // star bucket comes as first, also note we're not asserting on the count
   // in order to not depend on data too much
   result.[1] |> should startWith "\"*\",\"*\","
-  result.Length |> should equal 3
+  // at least one bucket on top of star bucket - low lowThreshold ensures this
+  result.Length |> should be (greaterThanOrEqualTo 3)
 
 [<Fact>]
 let ``Handles Export request for counting entities`` () =
@@ -168,7 +169,8 @@ let ``Handles Export request for counting entities`` () =
   // star bucket comes as first, also note we're not asserting on the count
   // in order to not depend on data too much
   result.[1] |> should startWith "\"*\",\"*\","
-  result.Length |> should equal 3
+  // at least one bucket on top of star bucket - low lowThreshold ensures this
+  result.Length |> should be (greaterThanOrEqualTo 3)
 
 [<Fact>]
 let ``Handles Export request with custom anonParams`` () =


### PR DESCRIPTION
The cosmetic change to random test data seeding done in `reference` caused an unfortunate data set, where was 100% suppression, and which the top-level tests didn't like.

This fixes that by:
  - lowering the default anon params used in the tests, to maximize chance of some unsuppressed bucket coming through
  - being more lax about the assertion - we only want to test that the star bucket is there in the export, not the actual suppression results

I tried some seeds in the data generator manually, we should be fine now.

Also, this PR bumps the reference - there is one more change present in the bump, which is the ORDER BY change. I decided to include this straight away, to have more control over when the "breaking" `generate.fsx` change hits, but we can also leave it out (or postpone merging till after the release is done).