### PR TITLE
Test the CSV exporting capabilities separately - stabilize Export tests

### DIFF
--- a/anonymizer/OpenDiffix.Service.Tests/CSVFormatter.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/CSVFormatter.Tests.fs
@@ -1,0 +1,82 @@
+module OpenDiffix.Service.CSVFormatterTests
+
+open Xunit
+open FsUnit.Xunit
+
+open OpenDiffix.Core
+open OpenDiffix.Core.QueryEngine
+
+[<Fact>]
+let ``Formats result with star bucket`` () =
+  let result =
+    {
+      Columns =
+        [
+          { Name = "age"; Type = IntegerType }
+          { Name = "city"; Type = StringType }
+          { Name = "discount"; Type = RealType }
+          { Name = "active"; Type = BooleanType }
+          { Name = "count"; Type = IntegerType }
+        ]
+      Rows = [ [| Integer 18L; String "Berlin"; Real 0.5; Boolean true; Integer 1L |] ]
+    }
+
+  let suppressedAnonCount = Integer 2L
+  let CSVResult = (CSVFormatter.format suppressedAnonCount result).Split('\n')
+
+  CSVResult.[0]
+  |> should equal "\"age\",\"city\",\"discount\",\"active\",\"count\""
+
+  CSVResult.[1] |> should equal "\"*\",\"*\",\"*\",\"*\",2"
+  CSVResult.[2] |> should equal "18,\"Berlin\",0.5,True,1"
+  CSVResult.Length |> should equal 3
+
+[<Fact>]
+let ``Formats result without the star bucket`` () =
+  let result =
+    {
+      Columns = [ { Name = "count"; Type = IntegerType } ]
+      Rows = [ [| Integer 1L |] ]
+    }
+
+  let suppressedAnonCount = Null
+  let CSVResult = (CSVFormatter.format suppressedAnonCount result).Split('\n')
+
+  CSVResult.[0] |> should equal "\"count\""
+  CSVResult.[1] |> should equal "1"
+  CSVResult.Length |> should equal 2
+
+[<Fact>]
+let ``Handles quotes`` () =
+  let result =
+    {
+      Columns = [ { Name = "name"; Type = StringType } ]
+      Rows = [ [| String "\"John Quoted\"" |] ]
+    }
+
+  let suppressedAnonCount = Null
+  let CSVResult = (CSVFormatter.format suppressedAnonCount result).Split('\n')
+
+  CSVResult.[1] |> should equal "\"\"\"John Quoted\"\"\""
+  CSVResult.Length |> should equal 2
+
+[<Fact>]
+let ``Formats nulls`` () =
+  let result =
+    {
+      Columns =
+        [
+          { Name = "age"; Type = IntegerType }
+          { Name = "city"; Type = StringType }
+          { Name = "discount"; Type = RealType }
+          { Name = "active"; Type = BooleanType }
+          { Name = "count"; Type = IntegerType }
+        ]
+      Rows = [ [| Null; Null; Null; Null; Null |] ]
+    }
+
+  let suppressedAnonCount = Null
+  let CSVResult = (CSVFormatter.format suppressedAnonCount result).Split('\n')
+
+  CSVResult.[1] |> should equal "NULL,NULL,NULL,NULL,NULL"
+  CSVResult.Length |> should equal 2

--- a/anonymizer/OpenDiffix.Service.Tests/CSVFormatter.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/CSVFormatter.Tests.fs
@@ -7,7 +7,7 @@ open OpenDiffix.Core
 open OpenDiffix.Core.QueryEngine
 
 [<Fact>]
-let ``Formats result with star bucket`` () =
+let ``Formats result`` () =
   let result =
     {
       Columns =
@@ -18,11 +18,14 @@ let ``Formats result with star bucket`` () =
           { Name = "active"; Type = BooleanType }
           { Name = "count"; Type = IntegerType }
         ]
-      Rows = [ [| Integer 18L; String "Berlin"; Real 0.5; Boolean true; Integer 1L |] ]
+      Rows =
+        [
+          [| String "*"; String "*"; String "*"; String "*"; Integer 2L |]
+          [| Integer 18L; String "Berlin"; Real 0.5; Boolean true; Integer 1L |]
+        ]
     }
 
-  let suppressedAnonCount = Integer 2L
-  let CSVResult = (CSVFormatter.format suppressedAnonCount result).Split('\n')
+  let CSVResult = (CSVFormatter.format result).Split('\n')
 
   CSVResult.[0]
   |> should equal "\"age\",\"city\",\"discount\",\"active\",\"count\""
@@ -32,21 +35,6 @@ let ``Formats result with star bucket`` () =
   CSVResult.Length |> should equal 3
 
 [<Fact>]
-let ``Formats result without the star bucket`` () =
-  let result =
-    {
-      Columns = [ { Name = "count"; Type = IntegerType } ]
-      Rows = [ [| Integer 1L |] ]
-    }
-
-  let suppressedAnonCount = Null
-  let CSVResult = (CSVFormatter.format suppressedAnonCount result).Split('\n')
-
-  CSVResult.[0] |> should equal "\"count\""
-  CSVResult.[1] |> should equal "1"
-  CSVResult.Length |> should equal 2
-
-[<Fact>]
 let ``Handles quotes`` () =
   let result =
     {
@@ -54,8 +42,7 @@ let ``Handles quotes`` () =
       Rows = [ [| String "\"John Quoted\"" |] ]
     }
 
-  let suppressedAnonCount = Null
-  let CSVResult = (CSVFormatter.format suppressedAnonCount result).Split('\n')
+  let CSVResult = (CSVFormatter.format result).Split('\n')
 
   CSVResult.[1] |> should equal "\"\"\"John Quoted\"\"\""
   CSVResult.Length |> should equal 2
@@ -75,8 +62,7 @@ let ``Formats nulls`` () =
       Rows = [ [| Null; Null; Null; Null; Null |] ]
     }
 
-  let suppressedAnonCount = Null
-  let CSVResult = (CSVFormatter.format suppressedAnonCount result).Split('\n')
+  let CSVResult = (CSVFormatter.format result).Split('\n')
 
   CSVResult.[1] |> should equal ",,,,"
   CSVResult.Length |> should equal 2

--- a/anonymizer/OpenDiffix.Service.Tests/CSVFormatter.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/CSVFormatter.Tests.fs
@@ -78,5 +78,5 @@ let ``Formats nulls`` () =
   let suppressedAnonCount = Null
   let CSVResult = (CSVFormatter.format suppressedAnonCount result).Split('\n')
 
-  CSVResult.[1] |> should equal "NULL,NULL,NULL,NULL,NULL"
+  CSVResult.[1] |> should equal ",,,,"
   CSVResult.Length |> should equal 2

--- a/anonymizer/OpenDiffix.Service.Tests/OpenDiffix.Service.Tests.fsproj
+++ b/anonymizer/OpenDiffix.Service.Tests/OpenDiffix.Service.Tests.fsproj
@@ -5,6 +5,7 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CSVFormatter.Tests.fs" />
     <Compile Include="Program.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
@@ -145,13 +145,8 @@ let ``Handles Export request for counting rows`` () =
 
   request |> mainCore |> should equal ""
 
-  let result = System.IO.File.ReadAllLines(outputFile.Path)
-  result |> should contain "\"age\",\"city\",\"count\""
-  // star bucket comes as first, also note we're not asserting on the count
-  // in order to not depend on data too much
-  result.[1] |> should startWith "\"*\",\"*\","
-  // at least one bucket on top of star bucket - low lowThreshold ensures this
-  result.Length |> should be (greaterThanOrEqualTo 3)
+  System.IO.File.ReadAllLines(outputFile.Path)
+  |> should contain "\"age\",\"city\",\"count\""
 
 [<Fact>]
 let ``Handles Export request for counting entities`` () =
@@ -164,48 +159,5 @@ let ``Handles Export request for counting entities`` () =
 
   request |> mainCore |> should equal ""
 
-  let result = System.IO.File.ReadAllLines(outputFile.Path)
-  result |> should contain "\"age\",\"city\",\"count\""
-  // star bucket comes as first, also note we're not asserting on the count
-  // in order to not depend on data too much
-  result.[1] |> should startWith "\"*\",\"*\","
-  // at least one bucket on top of star bucket - low lowThreshold ensures this
-  result.Length |> should be (greaterThanOrEqualTo 3)
-
-[<Fact>]
-let ``Handles Export request with custom anonParams`` () =
-  use outputFile = new TempFile()
-
-  let suppressAllAnonParams =
-    """
-    {
-      "suppression": {
-        "lowThreshold": 300,
-        "layerSD": 1,
-        "lowMeanGap": 2
-      },
-      "outlierCount": {
-        "lower": 2,
-        "upper": 5
-        },
-        "topCount": {
-          "lower": 2,
-          "upper": 5
-        },
-        "layerNoiseSD": 1.0
-      }
-    """
-
-  let requestCustom =
-    $"""
-    {{"type":"Export",%s{defaultQueryParams suppressAllAnonParams},"countInput":"Rows","outputPath":"%s{outputFile.Path}"}}
-    """
-
-  requestCustom |> mainCore |> should equal ""
-
-  let result = System.IO.File.ReadAllLines(outputFile.Path)
-  // The custom anonymization params have ridiculous suppression threshold to suppress all buckets
-  // Assertion checks whether that's respected by the service
-  result |> should contain "\"age\",\"city\",\"count\""
-  // 1 (only header) - the star bucket got suppressed too!
-  result.Length |> should equal 1
+  System.IO.File.ReadAllLines(outputFile.Path)
+  |> should contain "\"age\",\"city\",\"count\""

--- a/anonymizer/OpenDiffix.Service/CSVFormatter.fs
+++ b/anonymizer/OpenDiffix.Service/CSVFormatter.fs
@@ -12,28 +12,14 @@ let private csvFormat value =
   | String string -> quoteString string
   | _ -> Value.toString value
 
-let format suppressedAnonCount (result: QueryResult) =
+let format (result: QueryResult) =
   let header =
     result.Columns
     |> List.map (fun column -> quoteString column.Name)
-    |> String.join ","
-
-  let starBucketRow =
-    result.Columns
-    |> List.map (
-      function
-      | { Name = "count" } -> csvFormat suppressedAnonCount
-      | _ -> csvFormat (Value.String "*")
-    )
     |> String.join ","
 
   let rows =
     result.Rows
     |> List.map (fun row -> row |> Array.map csvFormat |> String.join ",")
 
-  match suppressedAnonCount with
-  // no suppression took place _OR_ the star bucket was itself suppressed
-  | Null -> header :: rows |> String.join "\n"
-  // there was suppression and the star bucket wasn't suppressed
-  | Integer _ -> header :: starBucketRow :: rows |> String.join "\n"
-  | _ -> failwith "Unexpected value of SuppressedAnonCount"
+  header :: rows |> String.join "\n"

--- a/anonymizer/OpenDiffix.Service/CSVFormatter.fs
+++ b/anonymizer/OpenDiffix.Service/CSVFormatter.fs
@@ -8,6 +8,7 @@ let private quoteString (string: string) =
 
 let private csvFormat value =
   match value with
+  | Null -> ""
   | String string -> quoteString string
   | _ -> Value.toString value
 

--- a/anonymizer/OpenDiffix.Service/CSVFormatter.fs
+++ b/anonymizer/OpenDiffix.Service/CSVFormatter.fs
@@ -1,0 +1,38 @@
+module OpenDiffix.Service.CSVFormatter
+
+open OpenDiffix.Core
+open OpenDiffix.Core.QueryEngine
+
+let private quoteString (string: string) =
+  "\"" + string.Replace("\"", "\"\"") + "\""
+
+let private csvFormat value =
+  match value with
+  | String string -> quoteString string
+  | _ -> Value.toString value
+
+let format suppressedAnonCount (result: QueryResult) =
+  let header =
+    result.Columns
+    |> List.map (fun column -> quoteString column.Name)
+    |> String.join ","
+
+  let starBucketRow =
+    result.Columns
+    |> List.map (
+      function
+      | { Name = "count" } -> csvFormat suppressedAnonCount
+      | _ -> csvFormat (Value.String "*")
+    )
+    |> String.join ","
+
+  let rows =
+    result.Rows
+    |> List.map (fun row -> row |> Array.map csvFormat |> String.join ",")
+
+  match suppressedAnonCount with
+  // no suppression took place _OR_ the star bucket was itself suppressed
+  | Null -> header :: rows |> String.join "\n"
+  // there was suppression and the star bucket wasn't suppressed
+  | Integer _ -> header :: starBucketRow :: rows |> String.join "\n"
+  | _ -> failwith "Unexpected value of SuppressedAnonCount"

--- a/anonymizer/OpenDiffix.Service/OpenDiffix.Service.fsproj
+++ b/anonymizer/OpenDiffix.Service/OpenDiffix.Service.fsproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="JsonEncodersDecoders.fs" />
     <Compile Include="CSVDataProvider.fs" />
+    <Compile Include="CSVFormatter.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
A little thing I put off for a longer while - the original `Program` tests for service proved brittle twice - they relied on the random data and the suppression params just to test the functionalities of CSV formatting. This quick PR fixes it by introducing a dedicated module and testing it separately.