### PR TITLE
Fix bug with handling *-bucket and columns named `count`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Next version
+
+- Fixed input data with a "count" column resulting in incorrect suppress bin.
+
 ### Version 1.0.1
 
 - Adjusts the computation of the suppression threshold mean to spec.


### PR DESCRIPTION
Found by Edon in https://github.com/diffix/desktop/pull/327#discussion_r818406789. The handling in the Electron side of things (`Preview` requests) is fine, only `Export` requests were broken, contrary to what I posted there.

I admit, I had a hard time trying to make the code arranging columns and indices foolproof and readable. Unless you have any ideas to simplify this easily, it seems like making this code nice would require a larger uprooting (like making `QueryEngine` aware of what the columns it outputs represents (labels vs aggregators)... but this doesn't sound right).

