### PR TITLE
Make CSVDataProvider aware of inferred column types

### DIFF
--- a/anonymizer/OpenDiffix.Service.Tests/CSVDataProvider.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/CSVDataProvider.Tests.fs
@@ -1,0 +1,140 @@
+module OpenDiffix.Service.CSVDataProviderTests
+
+open Xunit
+open FsUnit.Xunit
+
+open System.IO
+
+open OpenDiffix.Core
+
+
+let private makeProvider csv =
+  new CSV.DataProvider(new StringReader(csv), new StringReader(csv)) :> IDataProvider
+
+let referenceSchema =
+  let csv =
+    $"""
+"age","city","discount","active"
+20,"Berlin",0.2,true
+"""
+
+  (makeProvider csv).GetSchema()
+
+[<Fact>]
+let ``Loads simple full CSV`` () =
+  let csv =
+    $"""
+"age","city","discount","active"
+20,"Berlin",0.2,true
+"""
+
+  (makeProvider csv).GetSchema()
+  |> should
+       equal
+       [
+         {
+           Name = "table"
+           Columns =
+             [
+               { Name = "RowIndex"; Type = IntegerType }
+               { Name = "age"; Type = IntegerType }
+               { Name = "city"; Type = StringType }
+               { Name = "discount"; Type = RealType }
+               { Name = "active"; Type = BooleanType }
+             ]
+         }
+       ]
+
+[<Fact>]
+let ``Tolerates nulls`` () =
+  let csv =
+    $"""
+"age","city","discount","active"
+,"Berlin",0.2,true
+20,,0.2,true
+20,"Berlin",,true
+20,"Berlin",0.2,
+,,,
+"""
+
+  (makeProvider csv).GetSchema() |> should equal referenceSchema
+
+[<Fact>]
+let ``Understands various boolean values`` () =
+  let csv =
+    $"""
+"age","city","discount","active"
+20,"Berlin",0.2,1
+20,"Berlin",0.2,0
+20,"Berlin",0.2,
+"""
+
+  (makeProvider csv).GetSchema() |> should equal referenceSchema
+
+  let csv2 =
+    $"""
+"age","city","discount","active"
+20,"Berlin",0.2,"true"
+20,"Berlin",0.2,TRUE
+20,"Berlin",0.2,
+20,"Berlin",0.2,FALSE
+"""
+
+  (makeProvider csv2).GetSchema() |> should equal referenceSchema
+
+[<Fact>]
+let ``Resolves mixed types towards text`` () =
+  let csv =
+    $"""
+"age","city","discount","active"
+20,0.2,0.2,true
+20,2,0.2,true
+20,true,0.2,true
+"""
+
+  (makeProvider csv).GetSchema() |> should equal referenceSchema
+
+[<Fact>]
+let ``Resolves mixed types towards real`` () =
+  let csv =
+    $"""
+"age","city","discount","active"
+20,"Berlin",0.2,true
+20,"Berlin",1,true
+20,"Berlin",1.000000e-15,true
+"""
+
+  (makeProvider csv).GetSchema() |> should equal referenceSchema
+
+[<Fact>]
+let ``Resolves empty columns as text`` () =
+  let csv =
+    $"""
+"age","city","discount","active"
+20,,0.2,true
+20,,0.2,true
+20,,0.2,true
+"""
+
+  (makeProvider csv).GetSchema() |> should equal referenceSchema
+
+[<Fact>]
+let ``Reads typed values`` () =
+  let csv =
+    $"""
+"age","city","discount","active"
+20,"Berlin",0.2,true
+,,,
+"""
+
+  let dummyTable = { Name = "table"; Columns = [] }
+  let allColumnIndices = [ 0; 1; 2; 3; 4 ]
+
+  (makeProvider csv).OpenTable(dummyTable, allColumnIndices)
+  |> List.ofSeq
+  |> should
+       equal
+       [
+         [| Integer 1L; Integer 20L; String "Berlin"; Real 0.2; Boolean true |]
+         [| Integer 2L; Null; String ""; Null; Null |]
+       ]

--- a/anonymizer/OpenDiffix.Service.Tests/OpenDiffix.Service.Tests.fsproj
+++ b/anonymizer/OpenDiffix.Service.Tests/OpenDiffix.Service.Tests.fsproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CSVFormatter.Tests.fs" />
+    <Compile Include="CSVDataProvider.Tests.fs" />
     <Compile Include="Program.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
+++ b/anonymizer/OpenDiffix.Service.Tests/Program.Tests.fs
@@ -103,6 +103,29 @@ let ``Handles Preview request for counting entities`` () =
   response |> should haveSubstring "rows"
 
 [<Fact>]
+let ``Preview request recognizes input data types correctly`` () =
+  let request =
+    $"""
+    {{"type":"Preview",%s{defaultQueryParams defaultAnonParams},"countInput":"Rows","rows":1000}}
+    """
+
+  let queryParamsCastAge =
+    $"""
+    "inputPath": "%s{dataPath}",
+    "aidColumn": "id",
+    "salt": "1",
+    "anonParams": %s{defaultAnonParams},
+    "buckets": ["cast(age as integer)", "city"]
+    """
+
+  let requestCastAge =
+    $"""
+    {{"type":"Preview",%s{queryParamsCastAge},"countInput":"Rows","rows":1000}}
+    """
+
+  request |> mainCore |> should equal (requestCastAge |> mainCore)
+
+[<Fact>]
 let ``Handles Preview request with custom anonParams`` () =
   let suppressNoneAnonParams =
     """

--- a/anonymizer/OpenDiffix.Service/CSVDataProvider.fs
+++ b/anonymizer/OpenDiffix.Service/CSVDataProvider.fs
@@ -18,22 +18,123 @@ let private openCsvStream stream =
 
   csv
 
-type DataProvider(stream: TextReader) =
-  let csv = openCsvStream stream
+type private TypeInfo = { IsEmpty: bool; IsBoolean: bool; IsInteger: bool; IsReal: bool }
 
-  new(dbPath: string) = new DataProvider(new StreamReader(dbPath))
+let private unknownTypeInfo = { IsEmpty = true; IsBoolean = true; IsInteger = true; IsReal = true }
+let private integerTypeInfo = { IsEmpty = false; IsBoolean = false; IsInteger = true; IsReal = true }
+
+let private parseBoolean (field: string) =
+  if field = "1" then
+    Boolean true
+  else if field = "0" then
+    Boolean false
+  else
+    match Boolean.TryParse field with
+    | (true, value) -> Boolean value
+    | (false, _) -> Null
+
+let private parseInt64 (field: string) =
+  match Int64.TryParse field with
+  | (true, value) -> Integer value
+  | (false, _) -> Null
+
+let private parseDouble (field: string) =
+  match Double.TryParse field with
+  | (true, value) -> Real value
+  | (false, _) -> Null
+
+let private tryInferType (field: string) =
+  if field = "" then
+    Some unknownTypeInfo
+  else
+    Some
+      {
+        IsEmpty = false
+        IsBoolean = parseBoolean field <> Null
+        IsInteger = parseInt64 field <> Null
+        IsReal = parseDouble field <> Null
+      }
+
+let private deriveColumnType (columnTypeInfo: TypeInfo) =
+  if columnTypeInfo.IsEmpty then StringType
+  else if columnTypeInfo.IsBoolean then BooleanType
+  else if columnTypeInfo.IsInteger then IntegerType
+  else if columnTypeInfo.IsReal then RealType
+  else StringType
+
+let private inferColumnTypes columnIndices (typeInfosByRow: TypeInfo option array list) =
+  let inferred =
+    columnIndices
+    |> List.map (fun i ->
+      typeInfosByRow
+      |> Seq.map (fun rowTypeInfo -> rowTypeInfo.[i].Value)
+      |> Seq.fold
+        (fun (acc: TypeInfo) fieldTypeInfo ->
+          { acc with
+              IsEmpty = acc.IsEmpty && fieldTypeInfo.IsEmpty
+              IsBoolean = acc.IsBoolean && fieldTypeInfo.IsBoolean
+              IsInteger = acc.IsInteger && fieldTypeInfo.IsInteger
+              IsReal = acc.IsReal && fieldTypeInfo.IsReal
+          }
+        )
+        unknownTypeInfo
+    )
+
+  let row = Array.create (List.max columnIndices + 1) (UnknownType "")
+
+  for inferredIndex, columnIndex in List.indexed columnIndices do
+    row.[columnIndex] <- deriveColumnType inferred.[inferredIndex]
+
+
+  row
+
+let private parse columnType field =
+  match columnType with
+  | BooleanType -> parseBoolean field
+  | IntegerType -> parseInt64 field
+  | RealType -> parseDouble field
+  | _ -> String field
+
+type DataProvider(stream: TextReader, streamForTypes: TextReader) =
+  let csv = openCsvStream stream
+  let csvForTypes = openCsvStream streamForTypes
+  let schemaColumnIndices = seq { 0 .. (csvForTypes.HeaderRecord.Length) } |> List.ofSeq
+
+  let inferredColumnTypes =
+    seq<TypeInfo option array> {
+      while csvForTypes.Read() do
+        let row = Array.create (csvForTypes.HeaderRecord.Length + 1) None
+
+        for index in schemaColumnIndices do
+          if index = 0 then
+            // `RowIndex` column, which isn't coming from the CSV file.
+            row.[0] <- Some integerTypeInfo
+          else
+            row.[index] <- csvForTypes.GetField(index - 1) |> tryInferType
+
+        yield row
+    }
+    |> Seq.truncate 1000
+    |> List.ofSeq
+    |> inferColumnTypes schemaColumnIndices
+
+  new(dbPath: string) = new DataProvider(new StreamReader(dbPath), new StreamReader(dbPath))
 
   interface IDisposable with
     member this.Dispose() =
       csv.Dispose()
       stream.Dispose()
+      csvForTypes.Dispose()
+      streamForTypes.Dispose()
 
   interface IDataProvider with
     member this.GetSchema() =
+
       let columns =
         csv.HeaderRecord
         |> Array.toList
-        |> List.map (fun name -> { Name = name; Type = StringType })
+        // `inferredColumnTypes.[0]` is reserved for `RowIndex`.
+        |> List.mapi (fun i name -> { Name = name; Type = inferredColumnTypes.[i + 1] })
 
       [
         {
@@ -57,7 +158,7 @@ type DataProvider(stream: TextReader) =
             if index = 0 then
               row.[0] <- Integer rowIndex
             else
-              row.[index] <- csv.GetField(index - 1) |> String
+              row.[index] <- csv.GetField(index - 1) |> parse inferredColumnTypes.[index]
 
           yield row
       }


### PR DESCRIPTION
closes #282 

In particular, this solves the problem I stumbled upon, which is that when you have an integer column in the input CSV, the type of it's bucket column, which comes out as exported from DfD depends:
1. If you don't generalize it, it will be exported as string (and surrounded by `"`s)
2. If you generalize it, it will be exported as int (without the `"`s)

I tried to follow the logic of type inference used in `desktop`, in typescript code. That is, if the column consistently follows some type, it will be that type, and we look only at the first 1000 rows, to make things manageable.

Sorry about the rough edges, but I thought I'd go ahead and PR early to get your feedback, before trying to figure out 100% myself. I'll leave some comments on what in particular is still bugging me.